### PR TITLE
feat: Populate remaining website links

### DIFF
--- a/src/_blog/events/README.md
+++ b/src/_blog/events/README.md
@@ -2,10 +2,10 @@
 title: Events
 type: Event
 data:
-  - name: 'Sample Event'
-    title: 'Sample Event'
-    path: https://github.com/ipfs-shipyard/ipfs-desktop/releases/tag/v0.13.2
-    date: 2020-09-12T00:00:00.000+00:00
+  - name: 'Wrap Up 2020 with IPFS and friends!'
+    title: 'Wrap Up 2020 with IPFS and friends!'
+    path: https://www.meetup.com/San-Francisco-IPFS/events/274910985/
+    date: 2020-12-11T12:00:00.000+00:00
     tags:
-      - meetup
+      - 'official meetup'
 ---

--- a/src/_blog/newscoverage/README.md
+++ b/src/_blog/newscoverage/README.md
@@ -7,46 +7,208 @@ data:
     path: https://www.coindesk.com/juan-benet-most-influential-2020
     date: 2020-12-09T00:00:00.000+00:00
     tags:
-      - interview
-  - name: IPFS is paving the way for a new digital economy (Modern Consensus)
-    title: IPFS is paving the way for a new digital economy (Modern Consensus)
+      - 'interview'
+  - name: 'IPFS is paving the way for a new digital economy (Modern Consensus)'
+    title: 'IPFS is paving the way for a new digital economy (Modern Consensus)'
     path: https://modernconsensus.com/commentary/opinion/ipfs-is-paving-the-way-for-a-new-digital-economy/
     date: 2020-10-08T06:00:00.000+00:00
-    tags: weekly
-  - name:
-      The Decentralized Web Could Help Preserve The Internet’s Data For 1,000 Years.
-      Here’s Why We Need IPFS To Build It (TechDirt)
-    title:
-      The Decentralized Web Could Help Preserve The Internet’s Data For 1,000 Years.
-      Here’s Why We Need IPFS To Build It (TechDirt)
+    tags: 'economy'
+  - name: 'The Decentralized Web Could Help Preserve The Internet’s Data For 1,000 Years. Here’s Why We Need IPFS To Build It (TechDirt)'
+    title: 'The Decentralized Web Could Help Preserve The Internet’s Data For 1,000 Years. Here’s Why We Need IPFS To Build It (TechDirt)'
     path: https://www.techdirt.com/articles/20200504/16050844431/decentralized-web-could-help-preserve-internets-data-1000-years-heres-why-we-need-ipfs-to-build-it.shtml#comments
     date: 2020-05-05T06:00:00.000+00:00
     tags:
-      - link
-  - name: Latest Version of Open Source IPFS Improves Performance (DevOps.com)
-    title: Latest Version of Open Source IPFS Improves Performance (DevOps.com)
+      - 'archiving'
+  - name: 'Latest Version of Open Source IPFS Improves Performance (DevOps.com)'
+    title: 'Latest Version of Open Source IPFS Improves Performance (DevOps.com)'
     path: https://devops.com/latest-version-of-open-source-ipfs-improves-performance/
     date: 2020-04-30T06:00:00.000+00:00
     tags:
-      - link
-  - name: Decentralized Web Protocol IPFS Has Its Biggest Update So Far (Cointelegraph)
-    title: Decentralized Web Protocol IPFS Has Its Biggest Update So Far (Cointelegraph)
+      - ''
+  - name: 'Decentralized Web Protocol IPFS Has Its Biggest Update So Far (Cointelegraph)'
+    title: 'Decentralized Web Protocol IPFS Has Its Biggest Update So Far (Cointelegraph)'
     path: https://cointelegraph.com/news/decentralized-web-protocol-ipfs-has-its-biggest-update-so-far
     date: 2020-04-28T06:00:00.000+00:00
-    tags: ''
-  - name: InterPlanetary File System Is Uncensorable During Coronavirus News Fog (Coindesk)
-    title: InterPlanetary File System Is Uncensorable During Coronavirus News Fog (Coindesk)
+    tags:
+      - ''
+  - name: 'InterPlanetary File System Is Uncensorable During Coronavirus News Fog (Coindesk)'
+    title: 'InterPlanetary File System Is Uncensorable During Coronavirus News Fog (Coindesk)'
     path: https://www.coindesk.com/interplanetary-file-system-is-uncensorable-during-coronavirus-news-fog
     date: 2020-03-18T06:00:00.000+00:00
-    tags: ''
-  - name: IPFS Emerges as Tool to Distribute Container Images (Container Journal)
-    title: IPFS Emerges as Tool to Distribute Container Images (Container Journal)
+    tags:
+      - 'censorship'
+  - name: 'IPFS Emerges as Tool to Distribute Container Images (Container Journal)'
+    title: 'IPFS Emerges as Tool to Distribute Container Images (Container Journal)'
     path: https://containerjournal.com/topics/container-management/ipfs-emerges-as-tool-to-distribute-container-images/
     date: 2020-03-02T07:00:00.000+00:00
-    tags: ''
-  - name: JavaScript apps going InterPlanetary (Alessandro Segala)
-    title: JavaScript apps going InterPlanetary (Alessandro Segala)
-    path: https://medium.com/@italypaleale/watch-javascript-apps-going-inter-planetary-e33dba615a48
-    date: 2020-01-20T07:00:00.000+00:00
-    tags: ''
+    tags:
+      - 'Docker'
+  - name: 'IPFS, libp2p and Filecoin with Juan Benet (Zero Knowledge)'
+    title: 'IPFS, libp2p and Filecoin with Juan Benet (Zero Knowledge)'
+    path: https://www.zeroknowledge.fm/106?t=0
+    date: 2019-12-04T07:00:00.000+00:00
+    tags:
+      - 'interview'
+  - name: 'Enterprise IPFS for True Supply Chain Provenance (RTrade)'
+    title: 'Enterprise IPFS for True Supply Chain Provenance (RTrade)'
+    path: https://medium.com/rtrade-technologies/enterprise-ipfs-for-true-supply-chain-provenance-part-1-89524337f27
+    date: 2019-09-06T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'IPFS: Technology That’s Out of This World (Sprint)'
+    title: 'IPFS: Technology That’s Out of This World (Sprint)'
+    path: https://business.sprint.com/blog/ipfs-technology/
+    date: 2019-05-22T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'CloudFlare Goes InterPlanetary'
+    title: 'CloudFlare Goes InterPlanetary'
+    path: https://blog.cloudflare.com/distributed-web-gateway/
+    date: 2018-09-17T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Building Cooperation and Trust into the Web'
+    title: 'Building Cooperation and Trust into the Web'
+    path: https://hacks.mozilla.org/2018/08/dweb-building-cooperation-and-trust-into-the-web-with-ipfs/
+    date: 2018-08-29T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Deconstructing the Power Structures of Large-Scale Social Computing Networks'
+    title: 'Deconstructing the Power Structures of Large-Scale Social Computing Networks'
+    path: https://infocivics.com/
+    date: 2018-08-06T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Why is Decentralized and Distributed File Storage Critical for a Better Web? (Coin Center)'
+    title: 'Why is Decentralized and Distributed File Storage Critical for a Better Web? (Coin Center)'
+    path: https://coincenter.org/entry/why-is-decentralized-and-distributed-file-storage-critical-for-a-better-web
+    date: 2017-06-20T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Protocol Labs (BlueYard Capital)'
+    title: 'Protocol Labs (BlueYard Capital)'
+    path: https://medium.com/@BlueYard/protocol-labs-35ceff61b031
+    date: 2017-05-18T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Protocol Labs (Union Square Ventures)'
+    title: 'Protocol Labs (Union Square Ventures)'
+    path: https://www.usv.com/blog/protocol-labs
+    date: 2017-05-18T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Turkey Can’t Block This Copy of Wikipedia (Observer)'
+    title: 'Turkey Can’t Block This Copy of Wikipedia (Observer)'
+    path: http://observer.com/2017/05/turkey-wikipedia-ipfs/
+    date: 2017-05-10T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Ethereum Meets Zcash? Why IPFS Plans a Multi-Blockchain Browser (CoinDesk)'
+    title: 'Ethereum Meets Zcash? Why IPFS Plans a Multi-Blockchain Browser (CoinDesk)'
+    path: https://www.coindesk.com/ethereum-meets-zcash-why-ipfs-plans-a-multi-blockchain-browser/
+    date: 2017-04-29T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'OpenBazaar Integrating IPFS to Help Keep Stores Open Longer (Nasdaq)'
+    title: 'OpenBazaar Integrating IPFS to Help Keep Stores Open Longer (Nasdaq)'
+    path: http://www.nasdaq.com/article/openbazaar-integrating-interplanetary-file-system-to-help-keep-stores-open-longer-cm606534
+    date: 2016-04-14T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'A Protocol That Changes Everything (John Lilic)'
+    title: 'A Protocol That Changes Everything (John Lilic)'
+    path: https://www.linkedin.com/pulse/introduction-ipfs-interplanetary-file-system-brief-post-john-lilic
+    date: 2015-10-19T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Epicenter Bitcoin Interviews Juan Benet'
+    title: 'Epicenter Bitcoin Interviews Juan Benet'
+    path: https://epicenter.tv/episode/100/
+    date: 2015-10-12T07:00:00.000+00:00
+    tags:
+      - 'interview'
+  - name: 'Decentralizing the Web with IPFS (Reseller Club)'
+    title: 'Decentralizing the Web with IPFS (Reseller Club)'
+    path: https://blog.resellerclub.com/decentralizing-the-web-with-ipfs/
+    date: 2015-10-12T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'FreeNAS Alpha Ships with IPFS as a Transport'
+    title: 'FreeNAS Alpha Ships with IPFS as a Transport'
+    path: http://www.freenas.org/whats-new/2015/10/announcing-freenas-10-alpha.html
+    date: 2015-10-09T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'IPFS at AndYetConf 2015'
+    title: 'IPFS at AndYetConf 2015'
+    path: http://andyetconf.com/
+    date: 2015-10-06T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: "Why the Internet Needs IPFS Before It's Too Late (TechCrunch)"
+    title: "Why the Internet Needs IPFS Before It's Too Late (TechCrunch)"
+    path: https://techcrunch.com/2015/10/04/why-the-internet-needs-ipfs-before-its-too-late/
+    date: 2015-10-04T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'A For-Life, Decentralized, Privacy-Respecting Web (Maxim Veksler)'
+    title: 'A For-Life, Decentralized, Privacy-Respecting Web (Maxim Veksler)'
+    path: https://medium.com/@mvxlr/ipfs-inter-planetary-file-system-65466e4129c6
+    date: 2015-09-23T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'IPFS Wants to Create a Permanent Web (Motherboard)'
+    title: 'IPFS Wants to Create a Permanent Web (Motherboard)'
+    path: https://motherboard.vice.com/en_us/article/78xgaq/the-interplanetary-file-system-wants-to-create-a-permanent-web
+    date: 2015-09-19T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'First Steps Toward Implementing Distributed Permanent Web (Hacked.com)'
+    title: 'First Steps Toward Implementing Distributed Permanent Web (Hacked.com)'
+    path: https://hacked.com/first-steps-toward-implementing-distributed-permanent-web-ipfs/
+    date: 2015-09-10T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'HTTP is Obsolete. It’s Time for the Distributed, Permanent Web (Neocities)'
+    title: 'HTTP is Obsolete. It’s Time for the Distributed, Permanent Web (Neocities)'
+    path: https://blog.neocities.org/its-time-for-the-permanent-web.html
+    date: 2015-09-08T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Juan Benet Interview (Software Engineering Daily)'
+    title: 'Juan Benet Interview (Software Engineering Daily)'
+    path: https://softwareengineeringdaily.com/2015/08/25/interplanetary-file-system-ipfs-with-juan-benet/
+    date: 2015-08-25T07:00:00.000+00:00
+    tags:
+      - 'interview'
+  - name: 'IPFS at Battlemesh 2015'
+    title: 'IPFS at Battlemesh 2015'
+    path: http://battlemesh.org/
+    date: 2015-08-03T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Portland Ctrl IPFS Meetup'
+    title: 'Portland Ctrl IPFS Meetup'
+    path: https://attending.io/events/ipfs-portland-meetup-the-permanent-distributed-web
+    date: 2015-07-22T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Holger Krekels EuroPython 2015 Keynote'
+    title: 'Holger Krekels EuroPython 2015 Keynote'
+    path: http://dietzel.me/2015/08/02/EuroPython-2015-Holger-Krekels-Keynote-about-the-interplanetary-filesystem-Wed-22nd-July-2015/
+    date: 2015-05-22T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'IPFS at Data Terra Nemo 2015'
+    title: 'IPFS at Data Terra Nemo 2015'
+    path: http://dtn.is/
+    date: 2015-05-23T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: "Juan Benet at O'Reilly Fluent Conf"
+    title: "Juan Benet at O'Reilly Fluent Conf"
+    path: https://conferences.oreilly.com/fluent/javascript-html-2015/public/schedule/speaker/204938
+    date: 2015-04-23T07:00:00.000+00:00
+    tags:
+      - ''
 ---

--- a/src/_blog/releasenotes/README.md
+++ b/src/_blog/releasenotes/README.md
@@ -2,10 +2,40 @@
 title: Release Notes
 type: Release notes
 data:
+  - name: 'IPFS Companion 2.17.0'
+    title: 'IPFS Companion 2.17.0'
+    path: https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.17.0
+    date: 2021-01-11T07:00:00.000+00:00
+    tags:
+      - 'IPFS Companion'
+  - name: 'js-ipfs 0.52.3'
+    title: 'js-ipfs 0.52.3'
+    path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.52.3
+    date: 2020-12-16T00:00:00.000+00:00
+    tags:
+      - 'js-ipfs'
   - name: 'IPFS Desktop 0.13.2'
     title: 'IPFS Desktop 0.13.2'
     path: https://github.com/ipfs-shipyard/ipfs-desktop/releases/tag/v0.13.2
-    date: 2020-09-12T00:00:00.000+00:00
+    date: 2020-10-12T00:00:00.000+00:00
     tags:
-      - IPFS Desktop
+      - 'IPFS Desktop'
+  - name: 'IPFS Web UI 2.11.4'
+    title: 'IPFS Web UI 2.11.4'
+    path: https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.11.4
+    date: 2020-10-12T00:00:00.000+00:00
+    tags:
+      - 'IPFS Web UI'
+  - name: 'go-ipfs 0.7.0'
+    title: 'go-ipfs 0.7.0'
+    path: https://github.com/ipfs/go-ipfs/releases/tag/v0.7.0
+    date: 2020-10-12T00:00:00.000+00:00
+    tags:
+      - 'go-ipfs'
+  - name: 'IPFS Cluster 0.13.0'
+    title: 'IPFS Cluster 0.13.0'
+    path: https://github.com/ipfs/ipfs-cluster/releases/tag/v0.13.0
+    date: 2020-10-12T00:00:00.000+00:00
+    tags:
+      - 'IPFS Cluster'
 ---

--- a/src/_blog/tutorials/README.md
+++ b/src/_blog/tutorials/README.md
@@ -43,4 +43,10 @@ data:
     tags:
       - 'ProtoSchool'
       - 'CID'
+  - name: 'Install IPFS on a Raspberry Pi 2'
+    title: 'Install IPFS on a Raspberry Pi 2'
+    path: https://www.siliconian.com/blog/16-bitcoin-blockchain/23-beginner-s-guide-to-installing-ipfs-on-a-raspberry-pi-2
+    date: 2015-05-02T07:00:00.000+00:00
+    tags:
+      - 'Raspberry Pi'
 ---

--- a/src/_blog/videos/README.md
+++ b/src/_blog/videos/README.md
@@ -2,10 +2,228 @@
 title: Videos
 type: Video
 data:
-  - name: 'Sample Video'
-    title: 'Sample Video'
-    path: https://github.com/ipfs-shipyard/ipfs-desktop/releases/tag/v0.13.2
-    date: 2020-09-12T00:00:00.000+00:00
+  - name: 'IPFS Camp 2019 Core Courses'
+    title: 'IPFS Camp 2019 Core Courses'
+    path: https://www.youtube.com/watch?list=PLuhRWgmPaHtSsHMhjeWpfOzr8tonPaePu&v=Y_-TWTmF_1I
+    date: 2020-05-06T07:00:00.000+00:00
     tags:
-      - demo
+      - 'IPFS Camp'
+      - 'tutorial'
+  - name: 'JavaScript apps going InterPlanetary (Alessandro Segala)'
+    title: 'JavaScript apps going InterPlanetary (Alessandro Segala)'
+    path: https://www.youtube.com/watch?v=OY-YnkVHJcc
+    date: 2020-01-20T07:00:00.000+00:00
+    tags:
+      - 'JavaScript'
+  - name: 'IPFS Camp 2019 Keynotes'
+    title: 'IPFS Camp 2019 Keynotes'
+    path: https://www.youtube.com/watch?list=PLuhRWgmPaHtSkKM3Rzp4MQ0Z1nf5Kq0tl&v=gUE5vhZoavQ
+    date: 2019-10-15T07:00:00.000+00:00
+    tags:
+      - 'IPFS Camp'
+  - name: 'IPFS Camp 2019 Lightning Talks and Demos'
+    title: 'IPFS Camp 2019 Lightning Talks and Demos'
+    path: https://www.youtube.com/watch?list=PLuhRWgmPaHtQVNQcBaCKg5kKhfOBv45Jb&v=nvO1MMRxu1Q
+    date: 2019-07-22T07:00:00.000+00:00
+    tags:
+      - 'IPFS Camp'
+      - 'demo'
+  - name: 'IPFS and the Permanent Web (Stanford Seminar)'
+    title: 'IPFS and the Permanent Web (Stanford Seminar)'
+    path: https://www.youtube.com/watch?v=HUVmypx9HGI
+    date: 2015-10-22T07:00:00.000+00:00
+    tags:
+      - 'demo'
+  - name: 'IPFS Alpha Demo'
+    title: 'IPFS Alpha Demo'
+    path: https://www.youtube.com/watch?v=8CMxDNuuAiQ
+    date: 2015-02-20T07:00:00.000+00:00
+    tags:
+      - 'demo'
+  - name: 'A Technical Introduction to IPFS with Héctor Sanjuán (Our Networks 2019)'
+    title: 'A Technical Introduction to IPFS with Héctor Sanjuán (Our Networks 2019)'
+    path: https://www.youtube.com/watch?v=hnigvVuoaIA
+    date: 2019-12-19T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Juan Benet on Building Web3 (Web3 Summit)'
+    title: 'Juan Benet on Building Web3 (Web3 Summit)'
+    path: https://www.youtube.com/watch?v=pJOG5Ql7ZD0
+    date: 2019-10-17T07:00:00.000+00:00
+    tags:
+      - 'interview'
+  - name: 'IPFS Basics Night (ProtoSchool Denver)'
+    title: 'IPFS Basics Night (ProtoSchool Denver)'
+    path: https://www.youtube.com/watch?v=D3MjB45YZsM
+    date: 2019-10-16T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Vasco Santos on a Decentralized World (OPO.js)'
+    title: 'Vasco Santos on a Decentralized World (OPO.js)'
+    path: https://www.youtube.com/watch?v=5pHl67qomec
+    date: 2019-08-06T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Alex Potsides on NPM on IPFS (OPO.js)'
+    title: 'Alex Potsides on NPM on IPFS (OPO.js)'
+    path: https://www.youtube.com/watch?v=umNL2VkIHe8
+    date: 2019-08-06T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'IPFS Explained (WWDC/AltConf)'
+    title: 'IPFS Explained (WWDC/AltConf)'
+    path: https://www.youtube.com/watch?v=a1qVSs-poLY
+    date: 2019-06-08T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Visualizing the Decentralized Web (NodeFest Tokyo)'
+    title: 'Visualizing the Decentralized Web (NodeFest Tokyo)'
+    path: https://www.youtube.com/watch?v=3Y76XWFhoco
+    date: 2019-06-01T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Juan Benet: What Exactly is Web3? (Web3 Summit)'
+    title: 'Juan Benet: What Exactly is Web3? (Web3 Summit)'
+    path: https://www.youtube.com/watch?v=l44z35vabvA
+    date: 2018-10-26T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'IPFS London Meetup'
+    title: 'IPFS London Meetup'
+    path: https://www.youtube.com/playlist?list=PLuhRWgmPaHtRdiy0HKNy4UZ4dKVUVL_KG
+    date: 2018-10-08T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Volker Mische on NOISE (IPFS Lisbon Meetup)'
+    title: 'Volker Mische on NOISE (IPFS Lisbon Meetup)'
+    path: https://www.youtube.com/watch?v=wldudAZTM4E
+    date: 2018-01-11T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Pedro Teixeira on CRDTs (IPFS Lisbon Meetup)'
+    title: 'Pedro Teixeira on CRDTs (IPFS Lisbon Meetup)'
+    path: https://www.youtube.com/watch?v=2VOF-Z-nLnQ
+    date: 2018-01-11T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'João Santos on Distributed Verifiable Claims (IPFS Lisbon Meetup)'
+    title: 'João Santos on Distributed Verifiable Claims (IPFS Lisbon Meetup)'
+    path: https://www.youtube.com/watch?v=4oIvWldzT4o
+    date: 2018-01-11T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: "Juan Benet: Decentralize Computing Before It's Too Late (EtherealSF)"
+    title: "Juan Benet: Decentralize Computing Before It's Too Late (EtherealSF)"
+    path: https://www.youtube.com/watch?v=Uo4rOvh8mDM
+    date: 2017-10-31T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'IPFS, CoinList, and the Filecoin ICO with Juan Benet and Dalton Caldwell (Y Combinator)'
+    title: 'IPFS, CoinList, and the Filecoin ICO with Juan Benet and Dalton Caldwell (Y Combinator)'
+    path: https://www.youtube.com/watch?v=iUVLuXjPAfg
+    date: 2017-06-30T07:00:00.000+00:00
+    tags:
+      - 'interview'
+  - name: 'Juan Benet on the Next Internet Revolution (TEDxSanFrancisco)'
+    title: 'Juan Benet on the Next Internet Revolution (TEDxSanFrancisco)'
+    path: https://www.youtube.com/watch?v=2RCwZDRwk48&t=449s
+    date: 2016-12-08T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Juan Benet on The Decentralized Web (Silicon Valley Ethereum Meetup)'
+    title: 'Juan Benet on The Decentralized Web (Silicon Valley Ethereum Meetup)'
+    path: https://www.youtube.com/watch?v=cU-n_m-snxQ&t=12s
+    date: 2016-10-23T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Juan Benet on Distributed Apps with IPFS (Full Stack Fest)'
+    title: 'Juan Benet on Distributed Apps with IPFS (Full Stack Fest)'
+    path: https://www.youtube.com/watch?v=jONZtXMu03w&t=76s
+    date: 2016-09-14T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Berlin IPFS/Blockstack Meetup'
+    title: 'Berlin IPFS/Blockstack Meetup'
+    path: https://www.youtube.com/watch?v=CAfagNmIeOE
+    date: 2016-06-02T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Berlin IPFS Meetup'
+    title: 'Berlin IPFS Meetup'
+    path: https://www.youtube.com/watch?v=UOC_QqtEJtg
+    date: 2016-04-02T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'IPFS Workshop with Juan Benet (Open Knowledge Ireland)'
+    title: 'IPFS Workshop with Juan Benet (Open Knowledge Ireland)'
+    path: https://www.youtube.com/watch?v=S65z5NHfUT0
+    date: 2016-01-21T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Juan Benet on IFPS (DEVCON1)'
+    title: 'Juan Benet on IFPS (DEVCON1)'
+    path: https://www.youtube.com/watch?v=ewpIi1y_KDc
+    date: 2016-01-15T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Redistributing the Web with IPFS (BattleMeshV8)'
+    title: 'Redistributing the Web with IPFS (BattleMeshV8)'
+    path: https://www.youtube.com/watch?v=KGIyneFfiRE
+    date: 2015-10-26T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Interview with Juan Benet (DEVCON1)'
+    title: 'Interview with Juan Benet (DEVCON1)'
+    path: https://www.youtube.com/watch?v=t7VjUKCdfpg
+    date: 2015-10-15T07:00:00.000+00:00
+    tags:
+      - 'interview'
+  - name: 'Ian Preston on IPFS (Redecentralize Conf)'
+    title: 'Ian Preston on IPFS (Redecentralize Conf)'
+    path: https://www.youtube.com/watch?v=TiCUIh7tNtU
+    date: 2015-10-18T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Containers at Hyperspeed (Container Camp)'
+    title: 'Containers at Hyperspeed (Container Camp)'
+    path: https://www.youtube.com/watch?v=vaIWRyotz4g
+    date: 2015-09-11T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Towards Universal Access to All Knowledge (Chaos Communication Camp)'
+    title: 'Towards Universal Access to All Knowledge (Chaos Communication Camp)'
+    path: https://www.youtube.com/watch?v=lKvoVxUQKD0
+    date: 2015-08-13T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Seattle Surf Incubator IPFS Meetup'
+    title: 'Seattle Surf Incubator IPFS Meetup'
+    path: https://vimeo.com/137657331
+    date: 2015-07-23T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Berlin Ethereum/IPFS Meetup'
+    title: 'Berlin Ethereum/IPFS Meetup'
+    path: https://www.youtube.com/watch?v=QlsBU2moRK4
+    date: 2015-05-22T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'BlockChain University Part 2'
+    title: 'BlockChain University Part 2'
+    path: https://www.youtube.com/watch?v=999q3_htKPU
+    date: 2015-05-05T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'BlockChain University Part 1'
+    title: 'BlockChain University Part 1'
+    path: https://www.youtube.com/watch?v=JhE_J1-BKJE
+    date: 2015-05-05T07:00:00.000+00:00
+    tags:
+      - ''
+  - name: 'Juan Benet on IPFS: The Permanent Web (Talks at Sourcegraph 003)'
+    title: 'Juan Benet on IPFS: The Permanent Web (Talks at Sourcegraph 003)'
+    path: https://www.youtube.com/watch?v=Fa4pckodM9g
+    date: 2014-07-22T07:00:00.000+00:00
+    tags:
+      - ''
 ---


### PR DESCRIPTION
Populate remaining links from Media page of existing site.
Will still need to add blog posts published between Weekly 110 and date of launch, but suggest we do that all at once closer to launch date.