### PR TITLE
feat: add 404 page

### DIFF
--- a/src/.vuepress/theme/components/Footer.vue
+++ b/src/.vuepress/theme/components/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="footer bg-gradient-6 text-white py-8 md:py-16">
+  <footer class="footer bg-gradient-6 text-white py-8 md:py-16 mt-auto">
     <div class="grid grid-cols-12 grid-margins">
       <NewsletterForm class="col-start-1 col-span-12 lg:pb-20" />
       <div class="col-start-0 md:col-start-1 col-span-12 md:col-span-12">

--- a/src/.vuepress/theme/components/base/Transitions.vue
+++ b/src/.vuepress/theme/components/base/Transitions.vue
@@ -10,9 +10,7 @@
     @leave="leave"
     @after-leave="afterLeave"
   >
-    <main :key="withKey">
-      <slot></slot>
-    </main>
+    <slot></slot>
   </transition>
 </template>
 
@@ -35,10 +33,6 @@ export default {
     appear: {
       type: Boolean,
       default: false,
-    },
-    withKey: {
-      type: String,
-      default: null,
     },
     beforeEnter: Func,
     enter: Func,

--- a/src/.vuepress/theme/layouts/404.vue
+++ b/src/.vuepress/theme/layouts/404.vue
@@ -1,10 +1,14 @@
 <template>
-  <Layout>
-    <div>
-      <div>
-        <h1>404</h1>
-        <blockquote>Nothing to see here.</blockquote>
-        <RouterLink to="/">Take me home.</RouterLink>
+  <Layout class="flex flex-col flex-grow">
+    <div class="bg-gradient-6 h-20"></div>
+    <div class="bg-gray-light flex flex-grow">
+      <div class="grid-margins w-full type-rich py-8">
+        <h1>Item not found</h1>
+        <hr class="border separator" />
+        <div>
+          This item has been moved or removed.
+          <RouterLink to="/">Back to home</RouterLink>
+        </div>
       </div>
     </div>
   </Layout>
@@ -20,3 +24,9 @@ export default {
   },
 }
 </script>
+
+<style scoped lang="postcss">
+.separator {
+  border-color: #e9e9ec;
+}
+</style>

--- a/src/.vuepress/theme/layouts/GlobalLayout.vue
+++ b/src/.vuepress/theme/layouts/GlobalLayout.vue
@@ -1,12 +1,12 @@
 <template>
-  <main>
+  <div class="flex flex-col min-h-screen">
     <Nav v-if="shouldDisplay('nav')" ref="nav" />
     <MobileNav v-if="shouldDisplay('nav')" />
-    <Transition :with-key="$page.key" appear :after-leave="leaveScroll">
+    <Transition appear :after-leave="leaveScroll">
       <component :is="layout" />
     </Transition>
     <Footer v-if="shouldDisplay('footer')" />
-  </main>
+  </div>
 </template>
 
 <script>

--- a/src/.vuepress/theme/layouts/Layout.vue
+++ b/src/.vuepress/theme/layouts/Layout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <main>
     <slot name="header"></slot>
     <DynamicContent
       v-if="$page.frontmatter.body"
@@ -7,7 +7,7 @@
     />
     <slot></slot>
     <slot name="footer"></slot>
-  </div>
+  </main>
 </template>
 
 <script>


### PR DESCRIPTION
This PR: 
- Changes the 404 page according to the image provided in #26
- Changes the layout components

**Additional notes:**
- You will notice I had to do a little [hack](https://github.com/ipfs/ipfs-blog/compare/feat/404-page?expand=1#diff-b79502026c054c99fc0728dabd45ca78c101b08b5daf6841eab3876c61253e28R3) for the 404 page because the header/nav doesn't have a background color. In the other pages we have the hero with the background color, but for this case I didn't really find a better way to do it.
- I noticed that we always had two `<main>` elements in the DOM and removed one of them.
- I added classes/styling to the top element inside the `GlobalLayout` component in order to make the footer always stay at the bottom of the screen.

Closes #26