### PR TITLE
fix: remove time from dates inside markdown files

### DIFF
--- a/src/_blog/academicpapers.md
+++ b/src/_blog/academicpapers.md
@@ -2,36 +2,35 @@
 title: Academic Papers
 type: Academic paper
 data:
-- name: 'IPFS: Content Addressed, Versioned, P2P File System'
-  title: 'IPFS: Content Addressed, Versioned, P2P File System'
-  path: https://github.com/ipfs/papers/raw/master/ipfs-cap2pfs/ipfs-p2p-file-system.pdf
-  date: 2014-07-24T00:00:00.000+00:00
-  tags:
-  - whitepaper
-  card_image: ''
-- name: A practicable approach towards secure key-based routing
-  title: A practicable approach towards secure key-based routing
-  path: https://web.archive.org/web/20170809130252id_/http://www.tm.uka.de/doc/SKademlia_2007.pdf
-  date: 2007-01-01T00:00:00.000+00:00
-  tags:
-  - Kademlia
-  - security
-  card_image: ''
-- name: Democratizing Content Publication with Coral
-  title: Democratizing Content Publication with Coral
-  path: https://web.archive.org/web/20181117012712/http://www.coralcdn.org/docs/coral-nsdi04.pdf
-  date: 2005-01-01T00:00:00.000+00:00
-  tags:
-  - CDN
-  - DHT
-  card_image: ''
-- name: 'Kademlia: A Peer-to-peer Information System Based on the XOR Metric'
-  title: 'Kademlia: A Peer-to-peer Information System Based on the XOR Metric'
-  path: https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
-  date: 2002-10-10T00:00:00.000+00:00
-  tags:
-  - Kademlia
-  - DHT
-  card_image: ''
-
+  - name: 'IPFS: Content Addressed, Versioned, P2P File System'
+    title: 'IPFS: Content Addressed, Versioned, P2P File System'
+    path: https://github.com/ipfs/papers/raw/master/ipfs-cap2pfs/ipfs-p2p-file-system.pdf
+    date: 2014-07-24
+    tags:
+      - whitepaper
+    card_image: ''
+  - name: A practicable approach towards secure key-based routing
+    title: A practicable approach towards secure key-based routing
+    path: https://web.archive.org/web/20170809130252id_/http://www.tm.uka.de/doc/SKademlia_2007.pdf
+    date: 2007-01-01
+    tags:
+      - Kademlia
+      - security
+    card_image: ''
+  - name: Democratizing Content Publication with Coral
+    title: Democratizing Content Publication with Coral
+    path: https://web.archive.org/web/20181117012712/http://www.coralcdn.org/docs/coral-nsdi04.pdf
+    date: 2005-01-01
+    tags:
+      - CDN
+      - DHT
+    card_image: ''
+  - name: 'Kademlia: A Peer-to-peer Information System Based on the XOR Metric'
+    title: 'Kademlia: A Peer-to-peer Information System Based on the XOR Metric'
+    path: https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
+    date: 2002-10-10
+    tags:
+      - Kademlia
+      - DHT
+    card_image: ''
 ---

--- a/src/_blog/announcing-js-ipfs-0.53.0.md
+++ b/src/_blog/announcing-js-ipfs-0.53.0.md
@@ -1,5 +1,5 @@
 ---
-date: 2021-01-19T07:00:00+0000
+date: 2021-01-19
 permalink: '/2021-01-19-js-ipfs-0-50/'
 translationKey: ''
 header_image: '/header-image-js-ipfs-placeholder.png'

--- a/src/_blog/events.md
+++ b/src/_blog/events.md
@@ -6,27 +6,27 @@ data:
     title: IPFS Community Meetup, February 2021
     path: https://www.meetup.com/San-Francisco-IPFS/events/276018298/
     card_image: '/2021-02-23-event-meetup.png'
-    date: 2021-01-23T07:00:00.000+00:00
+    date: 2021-01-23
     tags:
       - official meetup
   - name: Kick off the New Year with IPFS
     title: Kick off the New Year with IPFS
     path: https://www.meetup.com/San-Francisco-IPFS/events/275755941/
     card_image: '/2021-01-22-event-meetup.png'
-    date: 2021-01-22T07:00:00.000+00:00
+    date: 2021-01-22
     tags:
       - official meetup
   - name: Wrap Up 2020 with IPFS and friends!
     title: Wrap Up 2020 with IPFS and friends!
     path: https://www.meetup.com/San-Francisco-IPFS/events/274910985/
-    date: 2020-12-11T12:00:00.000+00:00
+    date: 2020-12-11
     tags:
       - official meetup
     card_image: '/2020-12-11-event-meetup.png'
   - name: Portland Ctrl IPFS Meetup
     title: Portland Ctrl IPFS Meetup
     path: https://attending.io/events/ipfs-portland-meetup-the-permanent-distributed-web
-    date: 2015-07-22T19:56:09.000+00:00
+    date: 2015-07-22
     tags:
       - conferences
 ---

--- a/src/_blog/explore-merkle-dags-at-protoschool.md
+++ b/src/_blog/explore-merkle-dags-at-protoschool.md
@@ -1,5 +1,5 @@
 ---
-date: 2021-01-14T07:00:00+0000
+date: 2021-01-14
 permalink: '/2021-01-14-explore-merkle-dags-at-protoschool/'
 translationKey: ''
 header_image: '/115-protoschool-merkle-dags.png'

--- a/src/_blog/go-ipfs-0.8.0-and-remote-pinning-is-here.md
+++ b/src/_blog/go-ipfs-0.8.0-and-remote-pinning-is-here.md
@@ -5,7 +5,7 @@ tags:
   - pinning
 title: go-IPFS 0.8.0, and Remote Pinning, is here!
 description: See what's new in go-ipfs 0.8.0 (spoiler - pins are easier)!
-date: 2021-02-20T05:00:00+0000
+date: 2021-02-20
 permalink: '/2021-02-19-go-ipfs-0-8-0/'
 translationKey: ''
 header_image: '/108407727-bac93800-71e9-11eb-93bd-89e25a8b4349.png'

--- a/src/_blog/hardening-the-ipfs-public-dht-against-eclipse-attacks.md
+++ b/src/_blog/hardening-the-ipfs-public-dht-against-eclipse-attacks.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-10-30T06:00:00+0000
+date: 2020-10-30
 permalink: '/2020-10-30-dht-hardening/'
 translationKey: ''
 header_image: '/112-dht-hardening.jpg'

--- a/src/_blog/hey-ethdenver-hack-on-ipfs-with-these-bounties.md
+++ b/src/_blog/hey-ethdenver-hack-on-ipfs-with-these-bounties.md
@@ -3,7 +3,7 @@ title: Hey ETHDenver, hack on IPFS with these bounties!
 description:
   Win prizes of up to $500 for building on IPFS, especially when you build
   with the recent browser integrations at ETHDenver
-date: 2021-02-04T07:00:00+0000
+date: 2021-02-04
 permalink: '/2021-02-04-ethdenver-bounties/'
 translationKey: ''
 header_image: '/eth2.png'

--- a/src/_blog/how-we-put-ipfs-in-brave.md
+++ b/src/_blog/how-we-put-ipfs-in-brave.md
@@ -1,5 +1,5 @@
 ---
-date: 2021-01-21T07:00:00+0000
+date: 2021-01-21
 permalink: '/2021-01-21-how-we-put-ipfs-in-brave/'
 translationKey: ''
 tags:

--- a/src/_blog/introducing-js-ipfs-0.54.0.md
+++ b/src/_blog/introducing-js-ipfs-0.54.0.md
@@ -1,7 +1,7 @@
 ---
 title: Introducing js-IPFS 0.54.0
 description: js-IPFS 0.54.0 brings UPnP NAT Hole Punching to your js-IPFS node
-date: 2021-02-03T07:00:00+0000
+date: 2021-02-03
 permalink: '/2021-02-03-js-ipfs-0-54/'
 translationKey: ''
 header_image: '/header-image-js-ipfs-placeholder.png'

--- a/src/_blog/ipfs-and-igalia-collaborate-on-dweb-in-browsers.md
+++ b/src/_blog/ipfs-and-igalia-collaborate-on-dweb-in-browsers.md
@@ -1,5 +1,5 @@
 ---
-date: 2021-01-15T07:00:00+0000
+date: 2021-01-15
 url: '/2021-01-15-ipfs-and-igalia-collaborate-on-dweb-in-browsers/'
 translationKey: ''
 header_image: '/ipfs-and-igalia-collaborate-on-dweb-in-browsers-header-image.png'

--- a/src/_blog/ipfs-at-ethdenver-2021.md
+++ b/src/_blog/ipfs-at-ethdenver-2021.md
@@ -1,18 +1,19 @@
 ---
 tags:
-- conferences
-- community
-- Ethereum
+  - conferences
+  - community
+  - Ethereum
 title: IPFS at ETHDenver 2021
-description: 'The IPFS community was at ETHDenver in full force: bounties, help desks,
+description:
+  'The IPFS community was at ETHDenver in full force: bounties, help desks,
   and our favorite—new projects!'
 author: Jenn Turner
-date: 2021-02-26 07:00:00 +0000
-permalink: "/2021-02-26-ipfs-at-ethdenver/"
+date: 2021-02-26
+permalink: '/2021-02-26-ipfs-at-ethdenver/'
 translationKey: ''
-header_image: "/2021-03-01-cardheader-ipfs-at-ethdenver.png"
-
+header_image: '/2021-03-01-cardheader-ipfs-at-ethdenver.png'
 ---
+
 The annual premier hackathon event for the North American Ethereum community, ETHDenver and ColoradoJam, has come to a close. The 2021 event was 100% virtual, utilizing the gaming platform Gamerjibe as a virtual event venue, creating a unique and refreshing way for the dweb community to gather together.
 
 ![ETHDenver & ColoradoJam 2021 Bounty, Track & Quadratic Funding Winners](/2021-02-26-blog-ethdenver-winners.png)
@@ -21,10 +22,10 @@ The annual premier hackathon event for the North American Ethereum community, ET
 
 When it came to building with IPFS, we saw NFT marketplaces, decentralized and off-chain gaming, platforms solving real world issues involving life insurance and genetic testing, and consistently created ways to lower barriers for wallet creation, token creation, and more.
 
-* 31 out 86 total projects submitted to ETHDenver applied for IPFS bounties
-* 64 out of 86 projects submitted applied for IPFS-ecosystem tooling bounties (the most popular being Ceramic, Textile and Metamask)
-* The IPFS project awarded bounties to 11 submissions for their creative use of IPFS
-* 32 of the 51 winning projects were award bounties for using IPFS-ecosystem tooling
+- 31 out 86 total projects submitted to ETHDenver applied for IPFS bounties
+- 64 out of 86 projects submitted applied for IPFS-ecosystem tooling bounties (the most popular being Ceramic, Textile and Metamask)
+- The IPFS project awarded bounties to 11 submissions for their creative use of IPFS
+- 32 of the 51 winning projects were award bounties for using IPFS-ecosystem tooling
 
 See all of the [ETHDenver submissions here](https://ethdenver2021.devfolio.co/submissions) and read [about the winners](https://medium.com/ethdenver/ethdenver-coloradojam-2021-bounty-track-quadratic-funding-winners-805cf5f2de76), too!
 
@@ -40,34 +41,34 @@ In lieu of a sponsor booth, the IPFS Help Desk returned! Folks from IPFS, Slate,
 
 ## On the main stage
 
-* 19 of the presentations featured were by crafted by folks in the IPFS ecosystem
-* Watch all of the [2021 presentations here](https://www.youtube.com/playlist?list=PLAy4HNUNlzRkiRQFnr-gu6CyddoVTxeTy)
-* We recommend watching:
-  * Matt Ober from Pinata hosted a technical workshop on [IPFS: The Global CID](https://www.youtube.com/watch?v=vttw1bjC2no&list=PLAy4HNUNlzRkiRQFnr-gu6CyddoVTxeTy&index=132)
-  * IPFS Ecosystem Lead Dietrich Ayala participated in [a panel on the bridge from Web2.0 > Web3](https://www.youtube.com/watch?v=OgzQAZj3Y-E&list=PLAy4HNUNlzRkiRQFnr-gu6CyddoVTxeTy&index=87) with Igor Mandrigin and Susie Batt from Opera, and Bradley Kam from Unstoppable Domains.
+- 19 of the presentations featured were by crafted by folks in the IPFS ecosystem
+- Watch all of the [2021 presentations here](https://www.youtube.com/playlist?list=PLAy4HNUNlzRkiRQFnr-gu6CyddoVTxeTy)
+- We recommend watching:
+  - Matt Ober from Pinata hosted a technical workshop on [IPFS: The Global CID](https://www.youtube.com/watch?v=vttw1bjC2no&list=PLAy4HNUNlzRkiRQFnr-gu6CyddoVTxeTy&index=132)
+  - IPFS Ecosystem Lead Dietrich Ayala participated in [a panel on the bridge from Web2.0 > Web3](https://www.youtube.com/watch?v=OgzQAZj3Y-E&list=PLAy4HNUNlzRkiRQFnr-gu6CyddoVTxeTy&index=87) with Igor Mandrigin and Susie Batt from Opera, and Bradley Kam from Unstoppable Domains.
 
 ## New projects in the ecosystem
 
 Here are just a few of the projects from ETHDenver that have us excited about building even more with IPFS!
 
-* **Documint**, an IDE for Ceramic providing developers with a powerful interface for viewing, creating, and editing smart documents.
-  * [Project submission](https://devfolio.co/submissions/documint-eb71)
-  * [Project site](https://documint.net/ )
-  * [Project GitHub](https://github.com/xops/documint)
-* **Gasless Wallet**, an Ethereum Virtual Machine (EVM) blockchain-agnostic wallet allowing users to pay transactions fee in any of the ERC-20 standard tokens.
-  * [Project submission](https://devfolio.co/submissions/gasless-wallet-b236)
-  * [Project site](https://bafybeiajtc3zk5or5d3yfdixssal3oyx5otpbxvribnefq54jfwvfkid5e.ipfs.infura-ipfs.io/)
-  * [Project GitHub](https://github.com/sftwr-prjct-dev/gasless)
-* **TruReview**, a censorship-resistant review platform, allowing people to store their rich text/image/video reviews with IDX and Ceramic (stored on IPFS).
-  * [Project submission](https://devfolio.co/submissions/blah-7859)
-  * [Project demo](https://www.figma.com/proto/0eMGJeHltlcCKp4eTqdl5u/True-Review?node-id=162%3A1521&viewport=879%2C-40%2C0.06251474469900131&scaling=contain&hotspot-hints=0)
-  * [Project GitHub](https://github.com/twos-complement/eth-denver-2021)
-* **Timelock**, a simple app that helps lock money for a future date using a smart contract, which is then posted to IPFS.
-  * [Project submission](https://devfolio.co/submissions/timelock-08af)
-  * [Project site](https://web3-time-lock.glitch.me/)
-* **Super Rinkeby**, a decentralized Super Mario-like game where you can magically change your character through an NFT purchase.
-  * [Project submission](https://devfolio.co/submissions/super-rinkeby-game-a88e)
-  * [Project site](http://superrinkeby.com/)
-  * [Project GitHub](https://github.com/leon-do/super-rinkeby-website)
+- **Documint**, an IDE for Ceramic providing developers with a powerful interface for viewing, creating, and editing smart documents.
+  - [Project submission](https://devfolio.co/submissions/documint-eb71)
+  - [Project site](https://documint.net/)
+  - [Project GitHub](https://github.com/xops/documint)
+- **Gasless Wallet**, an Ethereum Virtual Machine (EVM) blockchain-agnostic wallet allowing users to pay transactions fee in any of the ERC-20 standard tokens.
+  - [Project submission](https://devfolio.co/submissions/gasless-wallet-b236)
+  - [Project site](https://bafybeiajtc3zk5or5d3yfdixssal3oyx5otpbxvribnefq54jfwvfkid5e.ipfs.infura-ipfs.io/)
+  - [Project GitHub](https://github.com/sftwr-prjct-dev/gasless)
+- **TruReview**, a censorship-resistant review platform, allowing people to store their rich text/image/video reviews with IDX and Ceramic (stored on IPFS).
+  - [Project submission](https://devfolio.co/submissions/blah-7859)
+  - [Project demo](https://www.figma.com/proto/0eMGJeHltlcCKp4eTqdl5u/True-Review?node-id=162%3A1521&viewport=879%2C-40%2C0.06251474469900131&scaling=contain&hotspot-hints=0)
+  - [Project GitHub](https://github.com/twos-complement/eth-denver-2021)
+- **Timelock**, a simple app that helps lock money for a future date using a smart contract, which is then posted to IPFS.
+  - [Project submission](https://devfolio.co/submissions/timelock-08af)
+  - [Project site](https://web3-time-lock.glitch.me/)
+- **Super Rinkeby**, a decentralized Super Mario-like game where you can magically change your character through an NFT purchase.
+  - [Project submission](https://devfolio.co/submissions/super-rinkeby-game-a88e)
+  - [Project site](http://superrinkeby.com/)
+  - [Project GitHub](https://github.com/leon-do/super-rinkeby-website)
 
-Our thanks go out to the organizers of ETHDenver and ColoradoJam 2021, the amazing IPFS community for their participation, and of course, the ETHDenver builders who inspired us with their inventive projects.  We look forward to seeing what folks come up with next in the many more hackathons to come in 2021!
+Our thanks go out to the organizers of ETHDenver and ColoradoJam 2021, the amazing IPFS community for their participation, and of course, the ETHDenver builders who inspired us with their inventive projects. We look forward to seeing what folks come up with next in the many more hackathons to come in 2021!

--- a/src/_blog/ipfs-in-2021-call-for-proposals.md
+++ b/src/_blog/ipfs-in-2021-call-for-proposals.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-11-19T07:00:00+0000
+date: 2020-11-19
 permalink: '/2020-11-19-community-rfp/'
 translationKey: ''
 header_image: '/113-community-rfp.jpg'

--- a/src/_blog/ipfs-in-2021-thank-you-for-your-proposals.md
+++ b/src/_blog/ipfs-in-2021-thank-you-for-your-proposals.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-12-21T07:00:00+0000
+date: 2020-12-21
 permalink: '/2020-12-21-ipfs-in-2021/'
 translationKey: ''
 header_image: '/114-ipfs-2021.jpg'

--- a/src/_blog/ipfs-in-brave-native-access-to-the-distributed-web.md
+++ b/src/_blog/ipfs-in-brave-native-access-to-the-distributed-web.md
@@ -1,5 +1,5 @@
 ---
-date: 2021-01-19T07:00:00+0000
+date: 2021-01-19
 permalink: '/2021-01-19-ipfs-in-brave/'
 translationKey: ''
 tags:

--- a/src/_blog/ipfs-in-opera-touch-on-ios.md
+++ b/src/_blog/ipfs-in-opera-touch-on-ios.md
@@ -1,17 +1,18 @@
 ---
 title: IPFS in Opera Touch on iOS!
-description: Opera has now added support for IPFS addressing to Opera Touch, their
+description:
+  Opera has now added support for IPFS addressing to Opera Touch, their
   mobile browser for iOS.
-date: 2021-02-08T17:00:00.000+00:00
-permalink: "/2021-02-08-opera-ios-and-ipfs/"
+date: 2021-02-08
+permalink: '/2021-02-08-opera-ios-and-ipfs/'
 translationKey: ''
-header_image: "/opera-ipfs-header.png"
+header_image: '/opera-ipfs-header.png'
 tags:
-- browsers
-- mobile
+  - browsers
+  - mobile
 author: Dietrich Ayala
-
 ---
+
 In 2020 we announced a big moment for IPFS: The first official support of IPFS protocol addressing in a major browser, when [Opera released IPFS support in their Android browser](ipns://blog.ipfs.io/2020-03-30-ipfs-in-opera-for-android/ 'Opera Android IPFS announcement'). This was an important step in IPFS browser support generally, by building interest and momentum. We didn’t stop there, and we’ve got not just one… BUT TWO releases to share with you today:
 
 First, Opera has now added support for IPFS addressing to Opera Touch, their iOS browser.

--- a/src/_blog/join-us-at-ethdenver-2021-year-of-the-spork-marmot.md
+++ b/src/_blog/join-us-at-ethdenver-2021-year-of-the-spork-marmot.md
@@ -3,7 +3,7 @@ title: Join us at ETHDenver 2021, year of the Spork Marmot!
 description:
   Return of the IPFS Help Desk, plus join us for a full day of hacking
   IPFS!
-date: 2021-02-02T07:00:00+0000
+date: 2021-02-02
 permalink: '/2021-02-02-ipfs-at-ethdenver/'
 translationKey: ''
 header_image: '/eth1.png'

--- a/src/_blog/js-ipfs-0.51.0-adds-type-definitions-and-removes-secio.md
+++ b/src/_blog/js-ipfs-0.51.0-adds-type-definitions-and-removes-secio.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-10-29T06:00:00+0000
+date: 2020-10-29
 permalink: '/2020-10-29-js-ipfs-0-50/'
 translationKey: ''
 header_image: '/header-image-js-ipfs-placeholder.png'

--- a/src/_blog/libp2p-comes-to-protoschool.md
+++ b/src/_blog/libp2p-comes-to-protoschool.md
@@ -7,7 +7,7 @@ title: libp2p comes to ProtoSchool
 description:
   The ProtoSchool team is pleased to announce the launch of a shiny new
   multiple-choice tutorial introducing libp2p
-date: 2021-02-17T07:00:00+0000
+date: 2021-02-17
 permalink: '/2021-02-17-libp2p-comes-to-protoschool/'
 translationKey: ''
 header_image: '/124-libp2p-comes-to-protoschool.png'

--- a/src/_blog/newscoverage.md
+++ b/src/_blog/newscoverage.md
@@ -6,49 +6,49 @@ data:
     title: Cointelegraph Top 100 - Juan Benet (Cointelegraph)
     path: https://cointelegraph.com/top-people-in-crypto-and-blockchain/juan-benet
     card_image: '/2021-02-11-news-cointelegraph-juanbenet.png'
-    date: 2021-02-11T07:00:00.000+00:00
+    date: 2021-02-11
     tags: []
   - name: Brave Becomes First Browser to Offer Native IPFS Integration (Coindesk)
     title: Brave Becomes First Browser to Offer Native IPFS Integration (Coindesk)
     path: https://www.coindesk.com/brave-browser-native-ipfs-integration-decentralized-web
-    date: 2021-01-19T07:00:00.000+00:00
+    date: 2021-01-19
     tags:
       - browsers
     card_image: '/2021-01-19-news-brave-coindesk.png'
   - name: Brave browser now supports peer-to-peer IPFS protocol (Engadget)
     title: Brave browser now supports peer-to-peer IPFS protocol (Engadget)
     path: https://www.engadget.com/brave-ipfs-update-190545662.html
-    date: 2021-01-19T07:00:00.000+00:00
+    date: 2021-01-19
     tags:
       - browsers
     card_image: '/2021-01-19-news-brave-engadget.png'
   - name: How to Use the Uncensorable Web on Privacy Browser Brave (Decrypt)
     title: How to Use the Uncensorable Web on Privacy Browser Brave (Decrypt)
     path: https://decrypt.co/54686/how-to-use-the-uncensorable-web-on-privacy-browser-brave
-    date: 2021-01-19T07:00:00.000+00:00
+    date: 2021-01-19
     tags:
       - browsers
     card_image: '/2021-01-19-news-brave-decrypt.png'
   - name: Brave Becomes First Browser to Add Native IPFS Support (ZDNet)
     title: Brave Becomes First Browser to Add Native IPFS Support (ZDNet)
     path: https://www.zdnet.com/article/brave-becomes-first-browser-to-add-native-support-for-the-ipfs-protocol/
-    date: 2021-01-19T07:00:00.000+00:00
+    date: 2021-01-19
     tags:
       - browsers
     card_image: '/2021-01-19-news-brave-zdnet.png'
   - name: Brave Integrates IPFS (Brave Blog)
     title: Brave Integrates IPFS (Brave Blog)
     path: https://brave.com/brave-integrates-ipfs/
-    date: 2021-01-19T07:00:00.000+00:00
+    date: 2021-01-19
     card_image: '/2021-01-19-news-brave-braveblog.png'
   - name: Brave Bets on the Decentralized Web (The Register)
     title: Brave Bets on the Decentralized Web (The Register)
     path: https://www.theregister.com/2021/01/19/brave_decentralized_browser/
-    date: 2021-01-19T07:00:00.000+00:00
+    date: 2021-01-19
   - name: Brave Takes Step Towards Enabling a Decentralized Web (The Verge)
     title: Brave Takes Step Towards Enabling a Decentralized Web (The Verge)
     path: https://www.theverge.com/2021/1/19/22238334/brave-browser-ipfs-peer-to-peer-decentralized-transfer-protocol-http-nodes
-    date: 2021-01-19T07:00:00.000+00:00
+    date: 2021-01-19
     tags:
       - browsers
     card_image: '/2021-01-19-news-brave-verge.png'
@@ -59,14 +59,14 @@ data:
       We Need Alternatives to Big Tech; These Decentralized Tools Might Be The
       Answer  (New America)
     path: https://www.newamerica.org/oti/blog/decentralization-competition/
-    date: 2021-01-12T07:00:00.000+00:00
+    date: 2021-01-12
     tags:
       - browsers
     card_image: '/2021-01-12-news-bigtech-newamerica.png'
   - name: Cloudflare Unveils Gateway to Distributed Web With ENS, IPFS Integration
     title: Cloudflare Unveils Gateway to Distributed Web With ENS, IPFS Integration
     path: https://www.coindesk.com/cloudflare-unveils-gateway-to-distributed-web-with-ens-ipfs-integration
-    date: 2021-01-13T07:00:00.000+00:00
+    date: 2021-01-13
     tags:
       - community
       - static publishing
@@ -115,7 +115,7 @@ data:
   - name: IPFS Emerges as Tool to Distribute Container Images (Container Journal)
     title: IPFS Emerges as Tool to Distribute Container Images (Container Journal)
     path: https://containerjournal.com/topics/container-management/ipfs-emerges-as-tool-to-distribute-container-images/
-    date: 2020-03-02T07:00:00.000+00:00
+    date: 2020-03-02
     tags:
       - Docker
       - containerization
@@ -123,14 +123,14 @@ data:
   - name: IPFS, libp2p and Filecoin with Juan Benet (Zero Knowledge)
     title: IPFS, libp2p and Filecoin with Juan Benet (Zero Knowledge)
     path: https://www.zeroknowledge.fm/106?t=0
-    date: 2019-12-04T07:00:00.000+00:00
+    date: 2019-12-04
     tags:
       - interview
     card_image: '/2020-03-02-news-juanbenet-zeroknowledge.png'
   - name: Enterprise IPFS for True Supply Chain Provenance (RTrade)
     title: Enterprise IPFS for True Supply Chain Provenance (RTrade)
     path: https://medium.com/rtrade-technologies/enterprise-ipfs-for-true-supply-chain-provenance-part-1-89524337f27
-    date: 2019-09-06T07:00:00.000+00:00
+    date: 2019-09-06
     tags:
       - community
     card_image: '/2019-09-06-news-supplychain-rtrade.png'
@@ -141,7 +141,7 @@ data:
   - name: Cloudflare Goes InterPlanetary (Cloudflare Blog)
     title: Cloudflare Goes InterPlanetary (Cloudflare Blog)
     path: https://blog.cloudflare.com/distributed-web-gateway/
-    date: 2018-09-17T07:00:00.000+00:00
+    date: 2018-09-17
     tags:
       - CDN
       - community
@@ -149,14 +149,14 @@ data:
   - name: Building Cooperation and Trust into the Web (Mozilla Hacks)
     title: Building Cooperation and Trust into the Web (Mozilla Hacks)
     path: https://hacks.mozilla.org/2018/08/dweb-building-cooperation-and-trust-into-the-web-with-ipfs/
-    date: 2018-08-29T07:00:00.000+00:00
+    date: 2018-08-29
     tags:
       - community
     card_image: '/2018-08-29-news-supplychain-rtrade.png'
   - name: Deconstructing the Power Structures of Large-Scale Social Computing Networks
     title: Deconstructing the Power Structures of Large-Scale Social Computing Networks
     path: https://infocivics.com/
-    date: 2018-08-06T07:00:00.000+00:00
+    date: 2018-08-06
     tags:
       - identity
   - name:
@@ -166,119 +166,119 @@ data:
       Why is Decentralized and Distributed File Storage Critical for a Better Web?
       (Coin Center)
     path: https://coincenter.org/entry/why-is-decentralized-and-distributed-file-storage-critical-for-a-better-web
-    date: 2017-06-20T07:00:00.000+00:00
+    date: 2017-06-20
     card_image: '/2017-06-20-news-distributedstorage-coincenter.png'
   - name: Protocol Labs (BlueYard Capital)
     title: Protocol Labs (BlueYard Capital)
     path: https://medium.com/@BlueYard/protocol-labs-35ceff61b031
-    date: 2017-05-18T07:00:00.000+00:00
+    date: 2017-05-18
     card_image: '/2017-05-18-pl-blueyard.png'
   - name: Protocol Labs (Union Square Ventures)
     title: Protocol Labs (Union Square Ventures)
     path: https://www.usv.com/blog/protocol-labs
-    date: 2017-05-18T07:00:00.000+00:00
+    date: 2017-05-18
   - name: Turkey Can’t Block This Copy of Wikipedia (Observer)
     title: Turkey Can’t Block This Copy of Wikipedia (Observer)
     path: http://observer.com/2017/05/turkey-wikipedia-ipfs/
-    date: 2017-05-10T07:00:00.000+00:00
+    date: 2017-05-10
     tags:
       - censorship
     card_image: '/2017-05-10-news-wikipedia-observer.png'
   - name: Ethereum Meets Zcash? Why IPFS Plans a Multi-Blockchain Browser (CoinDesk)
     title: Ethereum Meets Zcash? Why IPFS Plans a Multi-Blockchain Browser (CoinDesk)
     path: https://www.coindesk.com/ethereum-meets-zcash-why-ipfs-plans-a-multi-blockchain-browser/
-    date: 2017-04-29T07:00:00.000+00:00
+    date: 2017-04-29
     card_image: '/2017-04-29-news-multiblockchain-coindesk.png'
   - name: OpenBazaar Integrating IPFS to Help Keep Stores Open Longer (Nasdaq)
     title: OpenBazaar Integrating IPFS to Help Keep Stores Open Longer (Nasdaq)
     path: http://www.nasdaq.com/article/openbazaar-integrating-interplanetary-file-system-to-help-keep-stores-open-longer-cm606534
-    date: 2016-04-14T07:00:00.000+00:00
+    date: 2016-04-14
     tags:
       - community
     card_image: '/2016-04-14-openbazaar-nasdaq.png'
   - name: A Protocol That Changes Everything (John Lilic)
     title: A Protocol That Changes Everything (John Lilic)
     path: https://www.linkedin.com/pulse/introduction-ipfs-interplanetary-file-system-brief-post-john-lilic
-    date: 2015-10-19T07:00:00.000+00:00
+    date: 2015-10-19
     card_image: '/2015-10-18-news-changeseverything.png'
   - name: Epicenter Bitcoin Interviews Juan Benet
     title: Epicenter Bitcoin Interviews Juan Benet
     path: https://epicenter.tv/episode/100/
-    date: 2015-10-12T07:00:00.000+00:00
+    date: 2015-10-12
     tags:
       - interview
     card_image: '/2015-10-12-news-juanbenet-epicenterbitcoin.png'
   - name: Decentralizing the Web with IPFS (Reseller Club)
     title: Decentralizing the Web with IPFS (Reseller Club)
     path: https://blog.resellerclub.com/decentralizing-the-web-with-ipfs/
-    date: 2015-10-12T07:00:00.000+00:00
+    date: 2015-10-12
     card_image: '/2015-10-12-news-decentralizingweb-resellerclub.png'
   - name: FreeNAS Alpha Ships with IPFS as a Transport
     title: FreeNAS Alpha Ships with IPFS as a Transport
     path: https://web.archive.org/web/20151011192538/http://www.freenas.org/whats-new/2015/10/announcing-freenas-10-alpha.html
-    date: 2015-10-09T07:00:00.000+00:00
+    date: 2015-10-09
     tags:
       - community
   - name: IPFS at AndYetConf 2015
     title: IPFS at AndYetConf 2015
     path: http://talks.benet.ai/2015-10-06-ipfs-013-andyetconf
-    date: 2015-10-06T07:00:00.000+00:00
+    date: 2015-10-06
     tags:
       - conferences
   - name: Why the Internet Needs IPFS Before It's Too Late (TechCrunch)
     title: Why the Internet Needs IPFS Before It's Too Late (TechCrunch)
     path: https://techcrunch.com/2015/10/04/why-the-internet-needs-ipfs-before-its-too-late/
-    date: 2015-10-04T07:00:00.000+00:00
+    date: 2015-10-04
     card_image: '/2015-10-04-news-toolate-techcrunch.png'
   - name: A For-Life, Decentralized, Privacy-Respecting Web (Maxim Veksler)
     title: A For-Life, Decentralized, Privacy-Respecting Web (Maxim Veksler)
     path: https://medium.com/@mvxlr/ipfs-inter-planetary-file-system-65466e4129c6
-    date: 2015-09-23T07:00:00.000+00:00
+    date: 2015-09-23
   - name: IPFS Wants to Create a Permanent Web (Motherboard)
     title: IPFS Wants to Create a Permanent Web (Motherboard)
     path: https://motherboard.vice.com/en_us/article/78xgaq/the-interplanetary-file-system-wants-to-create-a-permanent-web
-    date: 2015-09-19T07:00:00.000+00:00
+    date: 2015-09-19
     card_image: '/2020-09-18-news-permanent-vice.png'
   - name: First Steps Toward Implementing Distributed Permanent Web (Hacked.com)
     title: First Steps Toward Implementing Distributed Permanent Web (Hacked.com)
     path: https://web.archive.org/web/20150919135028/https://hacked.com/first-steps-toward-implementing-distributed-permanent-web-ipfs/
-    date: 2015-09-10T07:00:00.000+00:00
+    date: 2015-09-10
   - name: HTTP is Obsolete. It’s Time for the Distributed, Permanent Web (Neocities)
     title: HTTP is Obsolete. It’s Time for the Distributed, Permanent Web (Neocities)
     path: https://blog.neocities.org/its-time-for-the-permanent-web.html
-    date: 2015-09-08T07:00:00.000+00:00
+    date: 2015-09-08
     card_image: '/2015-09-08-news-dweb-neocities.png'
   - name: Juan Benet Interview (Software Engineering Daily)
     title: Juan Benet Interview (Software Engineering Daily)
     path: https://softwareengineeringdaily.com/2015/08/25/interplanetary-file-system-ipfs-with-juan-benet/
-    date: 2015-08-25T07:00:00.000+00:00
+    date: 2015-08-25
     tags:
       - interview
     card_image: '/2015-08-25-juanbenet-softwareengineeringdaily.png'
   - name: IPFS at Battlemesh 2015
     title: IPFS at Battlemesh 2015
     path: https://battlemesh.org/BattleMeshV8/Agenda
-    date: 2015-08-03T07:00:00.000+00:00
+    date: 2015-08-03
     tags:
       - conferences
   - name: Holger Krekels EuroPython 2015 Keynote
     title: Holger Krekels EuroPython 2015 Keynote
     path: http://dietzel.me/2015/08/02/EuroPython-2015-Holger-Krekels-Keynote-about-the-interplanetary-filesystem-Wed-22nd-July-2015/
-    date: 2015-05-22T07:00:00.000+00:00
+    date: 2015-05-22
     tags:
       - conferences
     card_image: '/2015-08-02-news-holgerkrekel-europython.png'
   - name: IPFS at Data Terra Nemo 2015
     title: IPFS at Data Terra Nemo 2015
     path: https://dtn.is/2015.html
-    date: 2015-05-23T07:00:00.000+00:00
+    date: 2015-05-23
     tags:
       - conferences
     card_image: '/2015-05-23-news-dataterranemo.png'
   - name: Juan Benet at O'Reilly Fluent Conf
     title: Juan Benet at O'Reilly Fluent Conf
     path: https://www.oreilly.com/library/view/fluent-conference-2015/9781491927786/
-    date: 2015-04-23T07:00:00.000+00:00
+    date: 2015-04-23
     tags:
       - conferences
 ---

--- a/src/_blog/releasenotes.md
+++ b/src/_blog/releasenotes.md
@@ -5,49 +5,49 @@ data:
   - name: 'IPFS Companion 2.17.0'
     title: 'IPFS Companion 2.17.0'
     path: https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.17.0
-    date: 2021-01-11T07:00:00.000+00:00
+    date: 2021-01-11
     tags:
       - 'IPFS Companion'
   - name: 'go-libp2p 0.13.0'
     title: 'go-libp2p 0.13.0'
     path: https://github.com/libp2p/go-libp2p/releases/tag/v0.13.0
-    date: 2020-12-19T00:00:00.000+00:00
+    date: 2020-12-19
     tags:
       - 'libp2p'
   - name: 'js-libp2p 0.30.0'
     title: 'js-libp2p 0.30.0'
     path: https://github.com/libp2p/js-libp2p/releases/tag/v0.30.0
-    date: 2020-12-16T00:00:00.000+00:00
+    date: 2020-12-16
     tags:
       - 'libp2p'
   - name: 'js-ipfs 0.52.3'
     title: 'js-ipfs 0.52.3'
     path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.52.3
-    date: 2020-12-16T00:00:00.000+00:00
+    date: 2020-12-16
     tags:
       - 'js-ipfs'
   - name: 'IPFS Desktop 0.13.2'
     title: 'IPFS Desktop 0.13.2'
     path: https://github.com/ipfs-shipyard/ipfs-desktop/releases/tag/v0.13.2
-    date: 2020-10-12T00:00:00.000+00:00
+    date: 2020-10-12
     tags:
       - 'IPFS Desktop'
   - name: 'IPFS Web UI 2.11.4'
     title: 'IPFS Web UI 2.11.4'
     path: https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.11.4
-    date: 2020-10-12T00:00:00.000+00:00
+    date: 2020-10-12
     tags:
       - 'IPFS Web UI'
   - name: 'go-ipfs 0.7.0'
     title: 'go-ipfs 0.7.0'
     path: https://github.com/ipfs/go-ipfs/releases/tag/v0.7.0
-    date: 2020-10-12T00:00:00.000+00:00
+    date: 2020-10-12
     tags:
       - 'go-ipfs'
   - name: 'IPFS Cluster 0.13.0'
     title: 'IPFS Cluster 0.13.0'
     path: https://github.com/ipfs/ipfs-cluster/releases/tag/v0.13.0
-    date: 2020-10-12T00:00:00.000+00:00
+    date: 2020-10-12
     tags:
       - 'IPFS Cluster'
 ---

--- a/src/_blog/tutorials.md
+++ b/src/_blog/tutorials.md
@@ -2,94 +2,93 @@
 title: Tutorials
 type: Tutorial
 data:
-- name: 'ProtoSchool: Introduction to libp2p'
-  title: 'ProtoSchool: Introduction to libp2p'
-  path: https://proto.school/introduction-to-libp2p
-  card_image: "/2021-02-17-cardheader-protoschool-intro-to-libp2p.jpg"
-  date: 2021-02-17T07:00:00.000+00:00
-  tags:
-  - ProtoSchool
-  - libp2p
-- name: How to Leverage Cloudflare and IPFS to Host a Free High-Availability Site
-  title: How to Leverage Cloudflare and IPFS to Host a Free High-Availability Site
-  path: https://coywolf.pro/webmaster/ipfs-distributed-web-cloudflare-host-site/
-  date: 2021-02-10T07:00:00.000+00:00
-  tags:
-  - static publishing
-  - IPFS Desktop
-  card_image: "/tutorial-20210210-cloudflare-ipfs.png"
-- name: 'ProtoSchool: Merkle DAGs — Structuring Data for the Distributed Web'
-  title: 'ProtoSchool: Merkle DAGs — Structuring Data for the Distributed Web'
-  path: https://proto.school/merkle-dags
-  date: 2021-01-14T07:00:00.000+00:00
-  tags:
-  - ProtoSchool
-  - DAG
-  - IPLD
-  - CID
-  card_image: "/2021-01-14-tutorial-protoschool-merkledags.png"
-- name: 'ProtoSchool: Anatomy of a CID'
-  title: 'ProtoSchool: Anatomy of a CID'
-  path: https://proto.school/anatomy-of-a-cid
-  date: 2020-03-16T00:00:00.000+00:00
-  tags:
-  - ProtoSchool
-  - CID
-  card_image: "/084-explore-the-anatomy-of-a-cid-on-protoschool-header-image.png"
-- name: 'ProtoSchool: Regular Files API'
-  title: 'ProtoSchool: Regular Files API'
-  path: https://proto.school/regular-files-api
-  date: 2020-09-12T00:00:00.000+00:00
-  tags:
-  - ProtoSchool
-  - API
-  - js-ipfs
-  card_image: "/2020-09-11-tutorial-protoschool-regularfilesapi.png"
-- name: 'ProtoSchool: Mutable File System'
-  title: 'ProtoSchool: Mutable File System'
-  path: https://proto.school/mutable-file-system
-  date: 2019-06-11T00:00:00.000+00:00
-  tags:
-  - ProtoSchool
-  - MFS
-  - js-ipfs
-  card_image: "/084-explore-the-anatomy-of-a-cid-on-protoschool-header-image.png"
-- name: 'ProtoSchool: Content Addressing on the Decentralized Web'
-  title: 'ProtoSchool: Content Addressing on the Decentralized Web'
-  path: https://proto.school/content-addressing
-  date: 2019-01-03T01:00:00.000+00:00
-  tags:
-  - ProtoSchool
-  - DAG
-  - CID
-  - js-ipfs
-  - IPLD
-  card_image: "/2021-01-12-tutorial-protoschool-contentaddressing.png"
-- name: 'ProtoSchool: Blogging on the Decentralized Web'
-  title: 'ProtoSchool: Blogging on the Decentralized Web'
-  path: https://proto.school/blog
-  date: 2018-08-01T00:00:00.000+00:00
-  tags:
-  - ProtoSchool
-  - static publishing
-  - js-ipfs
-  - " IPLD"
-  - DAG
-  card_image: "/2020-09-11-tutorial-protoschool-blogging.png"
-- name: 'ProtoSchool: P2P Data Links with Content Addressing'
-  title: 'ProtoSchool: P2P Data Links with Content Addressing'
-  path: https://proto.school/basics
-  date: 2018-07-31T06:00:00.000+00:00
-  tags:
-  - ProtoSchool
-  - CID
-  card_image: "/2020-09-11-tutorial-protoschool-datalinks.png"
-- name: Install IPFS on a Raspberry Pi 2
-  title: Install IPFS on a Raspberry Pi 2
-  path: https://www.siliconian.com/blog/16-bitcoin-blockchain/23-beginner-s-guide-to-installing-ipfs-on-a-raspberry-pi-2
-  date: 2015-05-02T07:00:00.000+00:00
-  tags:
-  - ProtoSchool
-  card_image: "/2015-05-02-tutorial-raspberrypi-siliconian.png"
-
+  - name: 'ProtoSchool: Introduction to libp2p'
+    title: 'ProtoSchool: Introduction to libp2p'
+    path: https://proto.school/introduction-to-libp2p
+    card_image: '/2021-02-17-cardheader-protoschool-intro-to-libp2p.jpg'
+    date: 2021-02-17
+    tags:
+      - ProtoSchool
+      - libp2p
+  - name: How to Leverage Cloudflare and IPFS to Host a Free High-Availability Site
+    title: How to Leverage Cloudflare and IPFS to Host a Free High-Availability Site
+    path: https://coywolf.pro/webmaster/ipfs-distributed-web-cloudflare-host-site/
+    date: 2021-02-10
+    tags:
+      - static publishing
+      - IPFS Desktop
+    card_image: '/tutorial-20210210-cloudflare-ipfs.png'
+  - name: 'ProtoSchool: Merkle DAGs — Structuring Data for the Distributed Web'
+    title: 'ProtoSchool: Merkle DAGs — Structuring Data for the Distributed Web'
+    path: https://proto.school/merkle-dags
+    date: 2021-01-14
+    tags:
+      - ProtoSchool
+      - DAG
+      - IPLD
+      - CID
+    card_image: '/2021-01-14-tutorial-protoschool-merkledags.png'
+  - name: 'ProtoSchool: Anatomy of a CID'
+    title: 'ProtoSchool: Anatomy of a CID'
+    path: https://proto.school/anatomy-of-a-cid
+    date: 2020-03-16
+    tags:
+      - ProtoSchool
+      - CID
+    card_image: '/084-explore-the-anatomy-of-a-cid-on-protoschool-header-image.png'
+  - name: 'ProtoSchool: Regular Files API'
+    title: 'ProtoSchool: Regular Files API'
+    path: https://proto.school/regular-files-api
+    date: 2020-09-12
+    tags:
+      - ProtoSchool
+      - API
+      - js-ipfs
+    card_image: '/2020-09-11-tutorial-protoschool-regularfilesapi.png'
+  - name: 'ProtoSchool: Mutable File System'
+    title: 'ProtoSchool: Mutable File System'
+    path: https://proto.school/mutable-file-system
+    date: 2019-06-11
+    tags:
+      - ProtoSchool
+      - MFS
+      - js-ipfs
+    card_image: '/084-explore-the-anatomy-of-a-cid-on-protoschool-header-image.png'
+  - name: 'ProtoSchool: Content Addressing on the Decentralized Web'
+    title: 'ProtoSchool: Content Addressing on the Decentralized Web'
+    path: https://proto.school/content-addressing
+    date: 2019-01-03
+    tags:
+      - ProtoSchool
+      - DAG
+      - CID
+      - js-ipfs
+      - IPLD
+    card_image: '/2021-01-12-tutorial-protoschool-contentaddressing.png'
+  - name: 'ProtoSchool: Blogging on the Decentralized Web'
+    title: 'ProtoSchool: Blogging on the Decentralized Web'
+    path: https://proto.school/blog
+    date: 2018-08-01
+    tags:
+      - ProtoSchool
+      - static publishing
+      - js-ipfs
+      - ' IPLD'
+      - DAG
+    card_image: '/2020-09-11-tutorial-protoschool-blogging.png'
+  - name: 'ProtoSchool: P2P Data Links with Content Addressing'
+    title: 'ProtoSchool: P2P Data Links with Content Addressing'
+    path: https://proto.school/basics
+    date: 2018-07-31
+    tags:
+      - ProtoSchool
+      - CID
+    card_image: '/2020-09-11-tutorial-protoschool-datalinks.png'
+  - name: Install IPFS on a Raspberry Pi 2
+    title: Install IPFS on a Raspberry Pi 2
+    path: https://www.siliconian.com/blog/16-bitcoin-blockchain/23-beginner-s-guide-to-installing-ipfs-on-a-raspberry-pi-2
+    date: 2015-05-02
+    tags:
+      - ProtoSchool
+    card_image: '/2015-05-02-tutorial-raspberrypi-siliconian.png'
 ---

--- a/src/_blog/videos.md
+++ b/src/_blog/videos.md
@@ -5,18 +5,18 @@ data:
   - name: Introducing IPFS Support in the Brave Browser
     title: Introducing IPFS Support in the Brave Browser
     path: https://www.youtube.com/watch?v=jTDkTQiKzJA
-    date: 2021-01-19T07:00:00.000+00:00
+    date: 2021-01-19
   - name: Mapping the InterPlanetary File System (Protocol Labs Research Series)
     title: Mapping the InterPlanetary File System (Protocol Labs Research Series)
     path: https://www.youtube.com/watch?v=jQI37Y25jwk
-    date: 2021-01-15T07:00:00.000+00:00
+    date: 2021-01-15
     tags:
       - research
       - 'infrastructure'
   - name: IPFS Camp 2019 Core Courses
     title: IPFS Camp 2019 Core Courses
     path: https://www.youtube.com/watch?list=PLuhRWgmPaHtSsHMhjeWpfOzr8tonPaePu&v=Y_-TWTmF_1I
-    date: 2020-05-06T07:00:00.000+00:00
+    date: 2020-05-06
     tags:
       - IPFS Camp
       - conferences
@@ -24,20 +24,20 @@ data:
   - name: JavaScript apps going InterPlanetary (Alessandro Segala)
     title: JavaScript apps going InterPlanetary (Alessandro Segala)
     path: https://www.youtube.com/watch?v=OY-YnkVHJcc
-    date: 2020-01-20T07:00:00.000+00:00
+    date: 2020-01-20
     tags:
       - conferences
   - name: IPFS Camp 2019 Keynotes
     title: IPFS Camp 2019 Keynotes
     path: https://www.youtube.com/watch?list=PLuhRWgmPaHtSkKM3Rzp4MQ0Z1nf5Kq0tl&v=gUE5vhZoavQ
-    date: 2019-10-15T07:00:00.000+00:00
+    date: 2019-10-15
     tags:
       - IPFS Camp
       - conferences
   - name: IPFS Camp 2019 Lightning Talks and Demos
     title: IPFS Camp 2019 Lightning Talks and Demos
     path: https://www.youtube.com/watch?list=PLuhRWgmPaHtQVNQcBaCKg5kKhfOBv45Jb&v=nvO1MMRxu1Q
-    date: 2019-07-22T07:00:00.000+00:00
+    date: 2019-07-22
     tags:
       - IPFS Camp
       - conferences
@@ -45,89 +45,89 @@ data:
   - name: IPFS and the Permanent Web (Stanford Seminar)
     title: IPFS and the Permanent Web (Stanford Seminar)
     path: https://www.youtube.com/watch?v=HUVmypx9HGI
-    date: 2015-10-22T07:00:00.000+00:00
+    date: 2015-10-22
     tags:
       - demo
   - name: IPFS Alpha Demo
     title: IPFS Alpha Demo
     path: https://www.youtube.com/watch?v=8CMxDNuuAiQ
-    date: 2015-02-20T07:00:00.000+00:00
+    date: 2015-02-20
     tags:
       - demo
   - name: A Technical Introduction to IPFS with Héctor Sanjuán (Our Networks 2019)
     title: A Technical Introduction to IPFS with Héctor Sanjuán (Our Networks 2019)
     path: https://www.youtube.com/watch?v=hnigvVuoaIA
-    date: 2019-12-19T07:00:00.000+00:00
+    date: 2019-12-19
     tags:
       - conferences
   - name: Juan Benet on Building Web3 (Web3 Summit)
     title: Juan Benet on Building Web3 (Web3 Summit)
     path: https://www.youtube.com/watch?v=pJOG5Ql7ZD0
-    date: 2019-10-17T07:00:00.000+00:00
+    date: 2019-10-17
     tags:
       - interview
   - name: IPFS Basics Night (ProtoSchool Denver)
     title: IPFS Basics Night (ProtoSchool Denver)
     path: https://www.youtube.com/watch?v=D3MjB45YZsM
-    date: 2019-10-16T07:00:00.000+00:00
+    date: 2019-10-16
   - name: Vasco Santos on a Decentralized World (OPO.js)
     title: Vasco Santos on a Decentralized World (OPO.js)
     path: https://www.youtube.com/watch?v=5pHl67qomec
-    date: 2019-08-06T07:00:00.000+00:00
+    date: 2019-08-06
     tags:
       - conferences
   - name: Alex Potsides on NPM on IPFS (OPO.js)
     title: Alex Potsides on NPM on IPFS (OPO.js)
     path: https://www.youtube.com/watch?v=umNL2VkIHe8
-    date: 2019-08-06T07:00:00.000+00:00
+    date: 2019-08-06
     tags:
       - conferences
   - name: IPFS Explained (WWDC/AltConf)
     title: IPFS Explained (WWDC/AltConf)
     path: https://www.youtube.com/watch?v=a1qVSs-poLY
-    date: 2019-06-08T07:00:00.000+00:00
+    date: 2019-06-08
     tags:
       - conferences
   - name: Visualizing the Decentralized Web (NodeFest Tokyo)
     title: Visualizing the Decentralized Web (NodeFest Tokyo)
     path: https://www.youtube.com/watch?v=3Y76XWFhoco
-    date: 2019-06-01T07:00:00.000+00:00
+    date: 2019-06-01
     tags:
       - conferences
   - name: 'Juan Benet: What Exactly is Web3? (Web3 Summit)'
     title: 'Juan Benet: What Exactly is Web3? (Web3 Summit)'
     path: https://www.youtube.com/watch?v=l44z35vabvA
-    date: 2018-10-26T07:00:00.000+00:00
+    date: 2018-10-26
     tags:
       - conferences
   - name: IPFS London Meetup
     title: IPFS London Meetup
     path: https://www.youtube.com/playlist?list=PLuhRWgmPaHtRdiy0HKNy4UZ4dKVUVL_KG
-    date: 2018-10-08T07:00:00.000+00:00
+    date: 2018-10-08
     tags:
       - official meetup
   - name: Volker Mische on NOISE (IPFS Lisbon Meetup)
     title: Volker Mische on NOISE (IPFS Lisbon Meetup)
     path: https://www.youtube.com/watch?v=wldudAZTM4E
-    date: 2018-01-11T07:00:00.000+00:00
+    date: 2018-01-11
     tags:
       - official meetup
   - name: Pedro Teixeira on CRDTs (IPFS Lisbon Meetup)
     title: Pedro Teixeira on CRDTs (IPFS Lisbon Meetup)
     path: https://www.youtube.com/watch?v=2VOF-Z-nLnQ
-    date: 2018-01-11T07:00:00.000+00:00
+    date: 2018-01-11
     tags:
       - official meetup
   - name: João Santos on Distributed Verifiable Claims (IPFS Lisbon Meetup)
     title: João Santos on Distributed Verifiable Claims (IPFS Lisbon Meetup)
     path: https://www.youtube.com/watch?v=4oIvWldzT4o
-    date: 2018-01-11T07:00:00.000+00:00
+    date: 2018-01-11
     tags:
       - official meetup
   - name: "Juan Benet: Decentralize Computing Before It's Too Late (EtherealSF)"
     title: "Juan Benet: Decentralize Computing Before It's Too Late (EtherealSF)"
     path: https://www.youtube.com/watch?v=Uo4rOvh8mDM
-    date: 2017-10-31T07:00:00.000+00:00
+    date: 2017-10-31
     tags:
       - conferences
   - name:
@@ -137,102 +137,102 @@ data:
       IPFS, CoinList, and the Filecoin ICO with Juan Benet and Dalton Caldwell
       (Y Combinator)
     path: https://www.youtube.com/watch?v=iUVLuXjPAfg
-    date: 2017-06-30T07:00:00.000+00:00
+    date: 2017-06-30
     tags:
       - interview
   - name: Juan Benet on the Next Internet Revolution (TEDxSanFrancisco)
     title: Juan Benet on the Next Internet Revolution (TEDxSanFrancisco)
     path: https://www.youtube.com/watch?v=2RCwZDRwk48&t=449s
-    date: 2016-12-08T07:00:00.000+00:00
+    date: 2016-12-08
     tags:
       - conferences
   - name: Juan Benet on The Decentralized Web (Silicon Valley Ethereum Meetup)
     title: Juan Benet on The Decentralized Web (Silicon Valley Ethereum Meetup)
     path: https://www.youtube.com/watch?v=cU-n_m-snxQ&t=12s
-    date: 2016-10-23T07:00:00.000+00:00
+    date: 2016-10-23
   - name: Juan Benet on Distributed Apps with IPFS (Full Stack Fest)
     title: Juan Benet on Distributed Apps with IPFS (Full Stack Fest)
     path: https://www.youtube.com/watch?v=jONZtXMu03w&t=76s
-    date: 2016-09-14T07:00:00.000+00:00
+    date: 2016-09-14
     tags:
       - conferences
   - name: Berlin IPFS/Blockstack Meetup
     title: Berlin IPFS/Blockstack Meetup
     path: https://www.youtube.com/watch?v=CAfagNmIeOE
-    date: 2016-06-02T07:00:00.000+00:00
+    date: 2016-06-02
   - name: Berlin IPFS Meetup
     title: Berlin IPFS Meetup
     path: https://www.youtube.com/watch?v=UOC_QqtEJtg
-    date: 2016-04-02T07:00:00.000+00:00
+    date: 2016-04-02
     tags:
       - official meetup
   - name: IPFS Workshop with Juan Benet (Open Knowledge Ireland)
     title: IPFS Workshop with Juan Benet (Open Knowledge Ireland)
     path: https://www.youtube.com/watch?v=S65z5NHfUT0
-    date: 2016-01-21T07:00:00.000+00:00
+    date: 2016-01-21
     tags:
       - conferences
   - name: Juan Benet on IFPS (DEVCON1)
     title: Juan Benet on IFPS (DEVCON1)
     path: https://www.youtube.com/watch?v=ewpIi1y_KDc
-    date: 2016-01-15T07:00:00.000+00:00
+    date: 2016-01-15
     tags:
       - conferences
   - name: Redistributing the Web with IPFS (BattleMeshV8)
     title: Redistributing the Web with IPFS (BattleMeshV8)
     path: https://www.youtube.com/watch?v=KGIyneFfiRE
-    date: 2015-10-26T07:00:00.000+00:00
+    date: 2015-10-26
     tags:
       - conferences
   - name: Interview with Juan Benet (DEVCON1)
     title: Interview with Juan Benet (DEVCON1)
     path: https://www.youtube.com/watch?v=t7VjUKCdfpg
-    date: 2015-10-15T07:00:00.000+00:00
+    date: 2015-10-15
     tags:
       - interview
   - name: Ian Preston on IPFS (Redecentralize Conf)
     title: Ian Preston on IPFS (Redecentralize Conf)
     path: https://www.youtube.com/watch?v=TiCUIh7tNtU
-    date: 2015-10-18T07:00:00.000+00:00
+    date: 2015-10-18
     tags:
       - conferences
   - name: Containers at Hyperspeed (Container Camp)
     title: Containers at Hyperspeed (Container Camp)
     path: https://www.youtube.com/watch?v=vaIWRyotz4g
-    date: 2015-09-11T07:00:00.000+00:00
+    date: 2015-09-11
     tags:
       - conferences
       - containerization
   - name: Towards Universal Access to All Knowledge (Chaos Communication Camp)
     title: Towards Universal Access to All Knowledge (Chaos Communication Camp)
     path: https://www.youtube.com/watch?v=lKvoVxUQKD0
-    date: 2015-08-13T07:00:00.000+00:00
+    date: 2015-08-13
     tags:
       - conferences
   - name: Seattle Surf Incubator IPFS Meetup
     title: Seattle Surf Incubator IPFS Meetup
     path: https://vimeo.com/137657331
-    date: 2015-07-23T07:00:00.000+00:00
+    date: 2015-07-23
   - name: Berlin Ethereum/IPFS Meetup
     title: Berlin Ethereum/IPFS Meetup
     path: https://www.youtube.com/watch?v=QlsBU2moRK4
-    date: 2015-05-22T07:00:00.000+00:00
+    date: 2015-05-22
   - name: BlockChain University Part 2
     title: BlockChain University Part 2
     path: https://www.youtube.com/watch?v=999q3_htKPU
-    date: 2015-05-05T07:00:00.000+00:00
+    date: 2015-05-05
     tags:
       - conferences
   - name: BlockChain University Part 1
     title: BlockChain University Part 1
     path: https://www.youtube.com/watch?v=JhE_J1-BKJE
-    date: 2015-05-05T07:00:00.000+00:00
+    date: 2015-05-05
     tags:
       - conferences
   - name: 'Juan Benet on IPFS: The Permanent Web (Talks at Sourcegraph 003)'
     title: 'Juan Benet on IPFS: The Permanent Web (Talks at Sourcegraph 003)'
     path: https://www.youtube.com/watch?v=Fa4pckodM9g
-    date: 2014-07-22T07:00:00.000+00:00
+    date: 2014-07-22
     tags:
       - conferences
 ---

--- a/src/_blog/weekly-110.md
+++ b/src/_blog/weekly-110.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-10-20T23:00:00.000+00:00
+date: 2020-10-20
 permalink: '/weekly-110/'
 translationKey: ipfs-weekly-110
 header_image: /header-image-weekly-newsletter.png

--- a/src/_blog/weekly-111.md
+++ b/src/_blog/weekly-111.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-10-28T06:00:00+0000
+date: 2020-10-28
 permalink: '/weekly-111/'
 translationKey: ipfs-weekly-111
 tags:

--- a/src/_blog/weekly-112.md
+++ b/src/_blog/weekly-112.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-11-04T07:00:00+0000
+date: 2020-11-04
 permalink: '/weekly-112/'
 translationKey: ipfs-weekly-112
 tags:

--- a/src/_blog/weekly-113.md
+++ b/src/_blog/weekly-113.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-11-11T07:00:00+0000
+date: 2020-11-11
 permalink: '/weekly-113/'
 translationKey: ipfs-weekly-113
 tags:

--- a/src/_blog/weekly-114.md
+++ b/src/_blog/weekly-114.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-11-18T07:00:00+0000
+date: 2020-11-18
 permalink: '/weekly-114/'
 translationKey: ipfs-weekly-114
 tags:

--- a/src/_blog/weekly-115.md
+++ b/src/_blog/weekly-115.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-11-25T07:00:00+0000
+date: 2020-11-25
 permalink: '/weekly-115/'
 translationKey: ipfs-weekly-115
 tags:

--- a/src/_blog/weekly-116.md
+++ b/src/_blog/weekly-116.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-12-02T07:00:00+0000
+date: 2020-12-02
 permalink: '/weekly-116/'
 translationKey: ipfs-weekly-116
 tags:

--- a/src/_blog/weekly-117.md
+++ b/src/_blog/weekly-117.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-12-09T07:00:00+0000
+date: 2020-12-09
 permalink: '/weekly-117/'
 translationKey: ipfs-weekly-117
 tags:

--- a/src/_blog/weekly-118.md
+++ b/src/_blog/weekly-118.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-12-16T07:00:00+0000
+date: 2020-12-16
 permalink: '/weekly-118/'
 translationKey: ipfs-weekly-118
 tags:

--- a/src/_blog/welcome-to-ipfs-weekly-119.md
+++ b/src/_blog/welcome-to-ipfs-weekly-119.md
@@ -1,5 +1,5 @@
 ---
-date: 2021-01-20T07:00:00+0000
+date: 2021-01-20
 permalink: '/weekly-119/'
 translationKey: ipfs-weekly-119
 tags:

--- a/src/_blog/welcome-to-ipfs-weekly-120.md
+++ b/src/_blog/welcome-to-ipfs-weekly-120.md
@@ -1,7 +1,7 @@
 ---
 title: Welcome to IPFS Weekly 120
 description: ''
-date: 2021-01-27T07:00:00+0000
+date: 2021-01-27
 permalink: '/weekly-120/'
 translationKey: ipfs-weekly-120
 header_image: '/header-image-weekly-newsletter.png'

--- a/src/_blog/welcome-to-ipfs-weekly-121.md
+++ b/src/_blog/welcome-to-ipfs-weekly-121.md
@@ -3,7 +3,7 @@ title: Welcome to IPFS Weekly 121
 description:
   ETHDenver 2021 kicks off this week, discover a love letter to IPFS, plus
   catch up on all of the presentation from the January virtual meetup!
-date: 2021-02-03T07:00:00+0000
+date: 2021-02-03
 permalink: '/weekly-121/'
 translationKey: ''
 header_image: '/header-image-weekly-newsletter.png'

--- a/src/_blog/welcome-to-ipfs-weekly-122.md
+++ b/src/_blog/welcome-to-ipfs-weekly-122.md
@@ -6,7 +6,7 @@ description:
   Opera adds support for IPFS addressing to Opera Touch, relive the Brave
   x IPFS partnership AMA, and join the first forum for researchers and academics working
   in the IPFS space!
-date: 2021-02-10T07:00:00+0000
+date: 2021-02-10
 permalink: '/weekly-122/'
 translationKey: ipfs-weekly-122
 header_image: '/header-image-weekly-newsletter.png'

--- a/src/_blog/welcome-to-ipfs-weekly-123.md
+++ b/src/_blog/welcome-to-ipfs-weekly-123.md
@@ -5,7 +5,7 @@ title: Welcome to IPFS Weekly 123
 description:
   See what people built at ETHDenver, hang out with IPFS and friends, plus
   your files for keeps forever - we promise!
-date: 2021-02-17T07:00:00+0000
+date: 2021-02-17
 permalink: '/weekly-123/'
 translationKey: ipfs-weekly-123
 header_image: '/header-image-weekly-newsletter.png'

--- a/src/_blog/welcome-to-ipfs-weekly-124.md
+++ b/src/_blog/welcome-to-ipfs-weekly-124.md
@@ -1,23 +1,25 @@
 ---
 tags:
-- weekly
+  - weekly
 title: Welcome to IPFS Weekly 124
 description: The latest on go-ipfs 0.8.0, plus ProtoSchool adds libp2p!
-date: 2021-02-24T07:00:00.000+00:00
-permalink: "/weekly-124/"
+date: 2021-02-24
+permalink: '/weekly-124/'
 translationKey: ipfs-weekly-124
-header_image: "/header-image-weekly-newsletter.png"
+header_image: '/header-image-weekly-newsletter.png'
 author: Jenn Turner
-
 ---
+
 Here’s what’s happening in the [InterPlanetary File System](https://ipfs.io/) galaxy!
 
 ## What’s new in go-ipfs 0.8.0?
+
 The latest release from the IPFS protocol is here, and with it, go-ipfs 0.8.0 brings the ability to ask remote services to pin data for you! Other features include remote MFS pinning, faster pinning, and help for DNSLink names on https:// subdomains.
 
 [Read more](https://blog.ipfs.io/2021-02-19-go-ipfs-0-8-0/)
 
 ## NEW: libp2p comes to ProtoSchool
+
 The best place to learn about decentralized technology, ProtoSchool, has recently added lip2p to their curriculum. Now learners can participate in code-free tutorials, intros to dweb concepts, hands-on coding challenging and more!
 
 [Read more](https://blog.ipfs.io/2021-02-17-libp2p-comes-to-protoschool/)
@@ -25,46 +27,52 @@ The best place to learn about decentralized technology, ProtoSchool, has recentl
 <iframe width="560" height="315" src="https://www.youtube.com/embed/TM7aW0NFOJM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## VIDEO: IPFS & libp2p in 2020
+
 In case you missed it—IPFS project lead Molly Mackinlay gave a 2020 year-in-review on the latest with the IPFS ecosystem at CSCON[0], a virtual blockchain conference, late last year. Check it out!
 
 ## Brand new on IPFS
-* [Fleek announced](https://blog.fleek.co/posts/filecoin-archiving-backup-fleek-sites-and-storage) automated Filecoin archiving and back up for all sites and storageon Fleek!
-* [fwupd](https://blogs.gnome.org/hughsie/2021/02/16/fwupd-1-5-6/), the Linux firmware update service used by Lenovo, Google, Acer, Dell and more, now supports IPFS!
-* [Check out this work](https://blog.davidburela.com/2020/11/16/ipfs-on-risc-v/) to get IPFS running on RISC-V, an OSS ISA used to create open microprocessors.
-* Wondering what are [blockchain domains](https://twitter.com/unstoppableweb/status/1363488491255037952), and how are they different from traditional .com domains?
+
+- [Fleek announced](https://blog.fleek.co/posts/filecoin-archiving-backup-fleek-sites-and-storage) automated Filecoin archiving and back up for all sites and storageon Fleek!
+- [fwupd](https://blogs.gnome.org/hughsie/2021/02/16/fwupd-1-5-6/), the Linux firmware update service used by Lenovo, Google, Acer, Dell and more, now supports IPFS!
+- [Check out this work](https://blog.davidburela.com/2020/11/16/ipfs-on-risc-v/) to get IPFS running on RISC-V, an OSS ISA used to create open microprocessors.
+- Wondering what are [blockchain domains](https://twitter.com/unstoppableweb/status/1363488491255037952), and how are they different from traditional .com domains?
 
 ## Around the ecosystem 🌏
+
 How to own [SubstraPunks](https://medium.com/coinmonks/how-to-own-substrapunks-the-first-nfts-in-live-substrate-blockchain-polkadot-f6c14531f039), the first NFTs in Live Substrate Blockchain from Polkadot.
 
 [The Graph](https://polygontech.medium.com/the-graph-expands-to-layer-2-blockchains-and-brings-indexed-open-data-to-polygon-2bad0c5a3338) expands to Layer 2 Blockchains and Brings Indexed Open Data to Polygon.
 
 Check out [OBJKT Swap](https://hicetnunc2000.medium.com/objkt-swap-62dbaf776336), built with IPFS.
 
-Reminder that [ENS Names Are NFTs](https://medium.com/the-ethereum-name-service/reminder-that-ens-names-are-nfts-what-this-means-for-your-names-b7bcbea8715e): What This Means for Your Names. 
+Reminder that [ENS Names Are NFTs](https://medium.com/the-ethereum-name-service/reminder-that-ens-names-are-nfts-what-this-means-for-your-names-b7bcbea8715e): What This Means for Your Names.
 
-[Fleek](https://medium.com/the-ethereum-name-service/cloudflare-and-fleek-make-ens-ipfs-site-deployment-as-easy-as-ever-262c990a7514) now makes deploying and maintaining an ENS+IPFS websites easier than ever! 
+[Fleek](https://medium.com/the-ethereum-name-service/cloudflare-and-fleek-make-ens-ipfs-site-deployment-as-easy-as-ever-262c990a7514) now makes deploying and maintaining an ENS+IPFS websites easier than ever!
 
 [Unstoppable Domains](https://twitter.com/unstoppableweb/status/1363608689643413505?s=20) is hosting an AMA on Clubhouse this Thursday to answer questions about blockchain domains, NFTs, and their recent Cloudflare announcement.
 
 From ETHDenver: [Tiles](https://tiles.mechanaut.xyz/) is a document browser and explorer that gives incredible insight into all the real-time activity happening on the Ceramic Network.
 
 ## Join us for the next IPFS community meetup
+
 Mark your calendars for March 23 now, and stay tuned for upcoming details on our featured speakers. Also, if you have an idea for a presentation or a lightning talk, now would be a great time to reach out!
 
 [Register for details](https://www.meetup.com/San-Francisco-IPFS/events/276123396/)
 
 ## Job hunting? Work on IPFS!
-[Senior Integration Engineer](https://textile.breezy.hr/p/cad4ea4bf0c9-senior-integrations-engineer): You will be responsible for providing technical leadership and guidance to our users while they are integrating with libp2p, IPFS, Filecoin, and Textile. Textile, Remote. 
 
-[Technical Project Manager (Infura)](https://boards.greenhouse.io/consensys/jobs/2507095): Track active projects, remove roadblocks, and support the development team in identifying and keeping up-to-date all project requirements. Manage project, feature, technical debt, and bug backlogs working across teams in prioritizing work and planning out sprints. ConsenSys, Remote. 
+[Senior Integration Engineer](https://textile.breezy.hr/p/cad4ea4bf0c9-senior-integrations-engineer): You will be responsible for providing technical leadership and guidance to our users while they are integrating with libp2p, IPFS, Filecoin, and Textile. Textile, Remote.
+
+[Technical Project Manager (Infura)](https://boards.greenhouse.io/consensys/jobs/2507095): Track active projects, remove roadblocks, and support the development team in identifying and keeping up-to-date all project requirements. Manage project, feature, technical debt, and bug backlogs working across teams in prioritizing work and planning out sprints. ConsenSys, Remote.
 
 [Ecosystem Developer](https://jobs.lever.co/3box/ec1093c5-ed31-483c-b1b3-49b07bd0bd2e): We are looking for a technical community manager to help us create a world-class developer ecosystem and experience around our open source community. 3Box, Remote.
 
-[Sr. Backend Engineer](https://boards.greenhouse.io/consensys/jobs/2426803): Have built systems at scale in the past and can discuss the architectural tradeoffs that went into them. Experience with data lakes, data warehousing, and OLAP technologies. Self-directed. We want you to own the systems you build. ConsenSys, Remote. 
+[Sr. Backend Engineer](https://boards.greenhouse.io/consensys/jobs/2426803): Have built systems at scale in the past and can discuss the architectural tradeoffs that went into them. Experience with data lakes, data warehousing, and OLAP technologies. Self-directed. We want you to own the systems you build. ConsenSys, Remote.
 
 **Next stop, Mars!**
 
 Get involved with IPFS by checking us out on [GitHub](https://github.com/ipfs), joining discussions on [our community forum](https://discuss.ipfs.io/), or hitting us up [in chat](https://riot.im/app/#/room/#ipfs:matrix.org). Have a suggestion? [Email us](mailto:newsletter@ipfs.io).
 
 Get the IPFS Weekly in your inbox, each Tuesday.
+
 <p><a href="https://ipfs.us4.list-manage.com/subscribe?u=25473244c7d18b897f5a1ff6b&amp;id=cad54b2230" class="button button-primary">Sign up now</a></p>


### PR DESCRIPTION
Removes the time from the `date` field inside markdown files. 

Closes #55