### PR TITLE
bug: make hero author consistent with "Blog & news" link

### DIFF
--- a/src/.vuepress/theme/components/blog/PostAuthor.vue
+++ b/src/.vuepress/theme/components/blog/PostAuthor.vue
@@ -11,10 +11,7 @@
       itemprop="name"
       class="flex flex-row"
     >
-      <span
-        class="text-blueGreenLight hover:underline cursor-pointer"
-        @click="handleAuthorClick(piece)"
-      >
+      <span :class="computedClassName" @click="handleAuthorClick(piece)">
         {{ piece }}
       </span>
       <span>{{
@@ -35,6 +32,12 @@ export default {
   name: 'PostAuthor',
   components: {},
   mixins: [Author],
+  props: {
+    light: {
+      type: Boolean,
+      default: null,
+    },
+  },
   computed: {
     ...mapState('appState', ['activeAuthor']),
     resolvedAuthorName() {
@@ -46,6 +49,12 @@ export default {
       }
 
       return resolvedName.split(/[,&]/g)
+    },
+    computedClassName() {
+      return [
+        'hover:underline cursor-pointer',
+        this.light ? 'text-blueGreenLight' : 'hover:text-blueGreen',
+      ]
     },
   },
   methods: {

--- a/src/.vuepress/theme/components/blog/PostHero.vue
+++ b/src/.vuepress/theme/components/blog/PostHero.vue
@@ -10,7 +10,7 @@
               v-if="author && author.name"
               :to="{ path: $localePath, query: { author: author.name } }"
             >
-              <PostAuthor v-bind="author" />
+              <PostAuthor v-bind="author" light />
             </router-link>
             <time
               class="text-gray"


### PR DESCRIPTION
The littlest PR of them all: noticed that author links in blog post headers weren't displaying the same way as "Blog & news" link. @jdiogopeixoto, please merge at your leisure 😊 

Before: 
![image](https://user-images.githubusercontent.com/1507828/109856309-940df700-7c16-11eb-8a20-2293d0cd8bbd.png)

After: 
![image](https://user-images.githubusercontent.com/1507828/109856339-9ec88c00-7c16-11eb-9fcb-de5798c1ecea.png)
