### PR TITLE
feat: remove external link indicator

### DIFF
--- a/src/.vuepress/theme/components/NavLink.vue
+++ b/src/.vuepress/theme/components/NavLink.vue
@@ -9,7 +9,6 @@
   </RouterLink>
   <a v-else :href="link" :target="target" :rel="rel">
     {{ item.text }}
-    <OutboundLink v-if="isBlankTarget" />
   </a>
 </template>
 


### PR DESCRIPTION
Removes the external link indicator from the `NavLink`. 
Closes #65 