### PR TITLE
WIP: Update readme to reflect development workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ This work is part of a larger product-market fit realignment/enhancement effort 
 
 ⚠️⚠️⚠️ **If you want to publish a blog post, don't do it here yet** — use [the existing blog](https://github.com/ipfs/blog) instead!
 
-## Authoring/deployment workflow
+## Authoring/deployment workflow for blog posts
 
-This blog uses the `staging` branch as a work-in-progress scratchpad, with the production site deployed from `main` via [Fleek](https://fleek.co/).
+This blog uses the `staging` branch as a work-in-progress scratchpad for blog content, with the production site deployed from `main` via [Fleek](https://fleek.co/).
 
 We use [Forestry](https://forestry.io) as a CMS-style environment, including perks like WYSIWYG editing and image upload/crop tools. If you're an IPFS core team member and don't have Forestry access, contact @jessicaschilling to arrange access and a quick orientation session. (If you prefer writing in Markdown, don't fear: Forestry also has a raw Markdown view.) 
 
 Forestry writes directly to `staging`, with previews available at https://ipfs-blog-staging.on.fleek.co/. Once a staged post is ready to go live, please PR `staging` to `main` using [this handy shortcut](https://github.com/ipfs/ipfs-blog/compare/main...staging?expand=1). *Note that if multiple posts are in-flight in staging and only one is approved to go live, your PR may need some massaging.*
+
+## Deployment workflow for platform development
+
+All development PRs (as opposed to blog posts) should be merged into `main`. 
 
 ## License
 


### PR DESCRIPTION
Thanks for flagging that the current instructions were for content updates @jdiogopeixoto! 

I've taken a shot at some edits to the readme to make that more clear. Would you mind updating this draft to accurately reflect the best way to preview dev work that will be merged to `main`? Is it only the Forestly changes in`staging` that can be previewed on Fleek? Do we need to run `npm run dev` or `vuepress build src` instead? 