### PR TITLE
Add comments hostnames for Companion locations

### DIFF
--- a/src/.vuepress/theme/layouts/BlogPost.vue
+++ b/src/.vuepress/theme/layouts/BlogPost.vue
@@ -50,6 +50,7 @@ export default {
     this.showComments =
       window.location.hostname === 'blog.ipfs.io' ||
       window.location.hostname === 'blog.ipfs.io.ipns.localhost:8080' ||
+      window.location.hostname === '127.0.0.1:8080/ipns/blog.ipfs.io/' ||
       window.location.hostname === 'ipfs-blog.on.fleek.co' ||
       window.location.hostname === 'ipfs-blog.on.fleek.co.ipns.localhost:8080' ||
       window.location.hostname === 'ipfs-blog-staging.on.fleek.co' ||


### PR DESCRIPTION
Closes https://github.com/ipfs/ipfs-blog/issues/80 by adding hostnames for blog locations when being viewed via IPFS Companion.