### PR TITLE
Update redirects

### DIFF
--- a/src/.vuepress/redirects
+++ b/src/.vuepress/redirects
@@ -1,2 +1,2 @@
 /hello-world /0-hello-worlds
-/2021-02-19-go-ipfs-0-6-0 2021-02-19-go-ipfs-0-8-0/
+/2021-02-19-go-ipfs-0-6-0 /2021-02-19-go-ipfs-0-8-0/


### PR DESCRIPTION
This PR updates `src/.vuepress.redirects` with aliases from the old Hugo blog. Surprisingly, there was only one.