### PR TITLE
Fix: newsletter submit UI fix

### DIFF
--- a/src/.vuepress/theme/components/blog/NewsletterForm.vue
+++ b/src/.vuepress/theme/components/blog/NewsletterForm.vue
@@ -24,9 +24,7 @@
       @submit="subscribeClick"
     >
       <div id="mc_embed_signup_scroll" class="grid gric-col-2 w-full">
-        <div
-          class="fields flex flex-col sm:flex-row flex-wrap col-start-1 col-span-2"
-        >
+        <div class="fields flex flex-col sm:flex-row col-start-1 col-span-2">
           <input
             id="mce-EMAIL"
             v-model="email"


### PR DESCRIPTION
On very specific breakpoint (dev tools select laptop MDPI dimensions) you'd get the following UI issue:

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/2353186/112819648-b6abf800-907c-11eb-8eed-5d188012df19.png">

By removing `flex-wrap` we can fix it and not affect other breakpoints:

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/2353186/112819769-d2af9980-907c-11eb-9721-735407c8fcf0.png">
