### PR TITLE
fix: enable prefetch

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -79,7 +79,6 @@ module.exports = {
         'ZH - All the latest information about the IPFS Project in one place: blog posts, release notes, videos, news coverage, and more.',
     },
   },
-  shouldPrefetch: () => false,
   head: require('./config/head'),
   dest: './dist',
   markdown: {


### PR DESCRIPTION
This PR re-enables auto pre-fetch of blog post pages so they are instantaneously loaded.
Was there a reason why we disabled this @jdiogopeixoto @cwaring?