### PR TITLE
fix: add footer link

### DIFF
--- a/src/.vuepress/theme/components/FooterLegal.vue
+++ b/src/.vuepress/theme/components/FooterLegal.vue
@@ -51,6 +51,14 @@
         target="_blank"
         @click="onLinkClick"
         >Privacy</a
+      >
+      |
+      <a
+        class="text-blueGreenLight hover:underline"
+        href="https://ipfs.io/legal/"
+        target="_blank"
+        @click="onLinkClick"
+        >DMCA</a
       ></span
     >
   </div>


### PR DESCRIPTION
Adds link to https://ipfs.io/legal/ in footer - this is different from the protocol.ai legal page referenced elsewhere in footer.

Before
![image](https://user-images.githubusercontent.com/1507828/113771678-ebedc100-96e0-11eb-9a0b-d1bd013ef427.png)

After
![image](https://user-images.githubusercontent.com/1507828/113771648-e2fcef80-96e0-11eb-8c3e-b1a96443e0b5.png)
