### PR TITLE
fix: support index.json file required by ipfs.io

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ipfs-blog",
       "version": "1.0.0",
       "dependencies": {
         "dayjs": "^1.10.4",
@@ -60,7 +59,8 @@
         "vuepress-plugin-clean-urls": "^1.1.2",
         "vuepress-plugin-ipfs": "^1.0.2",
         "vuepress-plugin-robots": "^1.0.1",
-        "vuepress-plugin-seo": "^0.1.4"
+        "vuepress-plugin-seo": "^0.1.4",
+        "xml2js": "^0.4.23"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -23831,6 +23831,28 @@
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true
     },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
@@ -44519,6 +44541,24 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+          "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+          "dev": true
+        }
+      }
     },
     "xmlbuilder": {
       "version": "13.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "npm run dev",
     "dev": "vuepress dev src",
-    "build": "vuepress build src",
+    "build": "vuepress build src && npm run postbuild",
+    "postbuild": "./scripts/latest-posts.js",
     "lint": "prettier --write \"**/*.{json,yaml,md}\" && run-p lint:**",
     "lint:eslint": "eslint --cache \"**/*.{js,vue}\" --fix",
     "lint:styles": "stylelint \"**/*.css\" \"src/.vuepress/**/*.css\" --fix"
@@ -56,7 +57,8 @@
     "vuepress-plugin-clean-urls": "^1.1.2",
     "vuepress-plugin-ipfs": "^1.0.2",
     "vuepress-plugin-robots": "^1.0.1",
-    "vuepress-plugin-seo": "^0.1.4"
+    "vuepress-plugin-seo": "^0.1.4",
+    "xml2js": "^0.4.23"
   },
   "husky": {
     "hooks": {

--- a/scripts/latest-posts.js
+++ b/scripts/latest-posts.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+'use strict'
+
+/**
+    The ipfs.io website requests for a blog.ipfs.io/index.json file
+    with the latest 4 posts.
+    This script parses the rss feed file index.xml and generates the
+    required index.json file.
+
+    @see https://github.com/ipfs/ipfs-blog/issues/104
+*/
+
+const fs = require('fs')
+const xml2js = require('xml2js')
+const dayjs = require('dayjs')
+
+const xmlFilePath = 'dist/index.xml'
+const jsonFilePath = 'dist/index.json'
+
+function generateJsonFile(xml) {
+  xml2js.parseString(xml, (error, dataObj) => {
+    if (error) {
+      console.error(error)
+      return process.exit(1)
+    }
+
+    const posts = dataObj.rss.channel[0].item.slice(0, 4).map((item) => ({
+      title: item.title[0],
+      date: dayjs(item.pubDate[0]).format('DD MMMM YYYY'),
+      url: item.link[0],
+      author: '',
+    }))
+
+    fs.writeFile(jsonFilePath, JSON.stringify({ posts }), (error) => {
+      if (error) {
+        console.error(error)
+        return process.exit(1)
+      }
+    })
+  })
+}
+
+fs.readFile(xmlFilePath, { encoding: 'utf-8' }, (error, data) => {
+  if (error) {
+    console.error(error)
+
+    if (error.code === 'ENOENT') {
+      console.error(
+        "rss xml file not found – couldn't generate the index.json file."
+      )
+    }
+
+    return process.exit(1)
+  }
+
+  generateJsonFile(data)
+})


### PR DESCRIPTION
Closes #104 

This is a temporary fix considering we can change this requirement in the re-platforming of ipfs.io.

Current generated file in blog.ipfs.io: https://blog.ipfs.io/index.json
This version: https://bafybeif3mvgk3omqvwybdyssfosz6t46ka24ulrngvkyhmmntstrjshwly.on.fleek.co/index.json
UI in ipfs.io:

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/2353186/113910744-1a4ac980-97d1-11eb-97ae-d0528849d3d9.png">

The `author` field is not used and we don't have it in the rss xml file, so I just kept it there with an empty string just in case.