### PR TITLE
fix: show SVGs on 404 page – use href instead of xlink:href

### DIFF
--- a/src/.vuepress/theme/components/base/SVGIcon.vue
+++ b/src/.vuepress/theme/components/base/SVGIcon.vue
@@ -8,10 +8,7 @@
     :viewBox="icon.viewBox"
   >
     <title v-if="!ariaHide" :id="`svg-title--${name}`">{{ title }}</title>
-    <use
-      :xlink:href="`#${icon.id}`"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-    />
+    <use :href="`#${icon.id}`" />
   </svg>
 </template>
 


### PR DESCRIPTION
full browser support now: https://caniuse.com/mdn-svg_elements_use_href