### PR TITLE
fix: use https on youtube thumbnail image url

### DIFF
--- a/src/.vuepress/theme/components/blog/LinkCard.vue
+++ b/src/.vuepress/theme/components/blog/LinkCard.vue
@@ -116,7 +116,7 @@ export default {
       const id =
         newPath.searchParams.get('v') || newPath.searchParams.get('list')
 
-      return `http://img.youtube.com/vi/${id}/0.jpg`
+      return `https://img.youtube.com/vi/${id}/0.jpg`
     },
   },
   methods: {


### PR DESCRIPTION
Chrome:

<img width="653" alt="image" src="https://user-images.githubusercontent.com/2353186/114064012-1f6f4d80-9891-11eb-8051-9b3383997b5c.png">

Firefox:

<img width="381" alt="image" src="https://user-images.githubusercontent.com/2353186/114064069-2b5b0f80-9891-11eb-997f-e31ccc6e6023.png">
