### PR TITLE
fix: blockquote color CSS

### DIFF
--- a/src/.vuepress/theme/styles/components/typography.css
+++ b/src/.vuepress/theme/styles/components/typography.css
@@ -44,7 +44,7 @@
     &:before {
       content: '';
       width: 4px;
-      @apply bg-gradient-5 h-full left-0 absolute;
+      @apply bg-gradient-6 h-full left-0 absolute;
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/ipfs/ipfs-blog/issues/122.

Changes blockquote left border gradient to match page header.