### PR TITLE
Content update: IPFS in Opera Touch for iOS 

### DIFF
--- a/src/_blog/086-ipfs-in-opera-for-android.md
+++ b/src/_blog/086-ipfs-in-opera-for-android.md
@@ -1,15 +1,15 @@
 ---
 date: 2020-03-30
-permalink: /2020-03-30-ipfs-in-opera-for-android/
+permalink: "/2020-03-30-ipfs-in-opera-for-android/"
 title: IPFS in Opera for Android
-description:
+description: 
 author: Dietrich Ayala
-header_image: /086-ipfs-in-opera-for-android-header-image.png
+header_image: "/086-ipfs-in-opera-for-android-header-image.png"
 tags:
-  - 'browsers'
-  - 'mobile'
----
+- browsers
+- mobile
 
+---
 ![IPFS built-in to Opera for Android](../assets/086-ipfs-in-opera-for-android-banner.png)
 
 As we hinted in our previous post about [IPFS in web browsers](https://blog.ipfs.io/2019-10-08-ipfs-browsers-update/), IPFS support in the Opera web browser has been in development for some time.
@@ -38,7 +38,7 @@ IPFS support is enabled by default, so as a user you don’t need to do anything
 
 You can load an IPFS content address such as:
 
-> [ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/](ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/)
+> <a href="ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/">ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/</a>
 
 If you click the link above in Opera for Android you’ll see Wikipedia, served from IPFS!
 
@@ -98,7 +98,7 @@ Making the default gateway configurable puts you, the user, in control of how yo
 
 ## Get Involved
 
-If you’re interested in IPFS in web browsers, join our channel on IRC on Freenode [#ipfs-in-web-browsers](ircs://irc.freenode.net/#ipfs-in-web-browsers) and [Matrix](https://matrix.to/#/!LiCFQLjSxdKuUVxokg:matrix.org?via=matrix.org&via=tomesh.net) to participate in the discussion!
+If you’re interested in IPFS in web browsers, join our channel on IRC on Freenode <a href="ircs://irc.freenode.net/#ipfs-in-web-browsers">#ipfs-in-web-browsers</a> and [Matrix](https://matrix.to/#/!LiCFQLjSxdKuUVxokg:matrix.org?via=matrix.org&via=tomesh.net) to participate in the discussion!
 
 You can file issues and follow along with our browser integration work at [ipfs/in-web-browsers](https://github.com/ipfs/in-web-browsers).
 

--- a/src/_blog/ipfs-in-opera-touch-on-ios.md
+++ b/src/_blog/ipfs-in-opera-touch-on-ios.md
@@ -1,42 +1,45 @@
 ---
 title: IPFS in Opera Touch on iOS!
-description:
-  Opera has now added support for IPFS addressing to Opera Touch, their
+description: Opera has now added support for IPFS addressing to Opera Touch, their
   mobile browser for iOS.
 date: 2021-02-08
-permalink: '/2021-02-08-opera-ios-and-ipfs/'
+permalink: "/2021-02-08-opera-ios-and-ipfs/"
 translationKey: ''
-header_image: '/opera-ipfs-header.png'
+header_image: "/opera-ipfs-header.png"
 tags:
-  - browsers
-  - mobile
+- browsers
+- mobile
 author: Dietrich Ayala
----
 
-In 2020 we announced a big moment for IPFS: The first official support of IPFS protocol addressing in a major browser, when [Opera released IPFS support in their Android browser](ipns://blog.ipfs.io/2020-03-30-ipfs-in-opera-for-android/ 'Opera Android IPFS announcement'). This was an important step in IPFS browser support generally, by building interest and momentum. We didn’t stop there, and we’ve got not just one… BUT TWO releases to share with you today:
+---
+In 2020 we announced a big moment for IPFS: The first official support of IPFS protocol addressing in a major browser, when [Opera released IPFS support in their Android browser](https://blog.ipfs.io/2020-03-30-ipfs-in-opera-for-android/). This was an important step in IPFS browser support generally, by building interest and momentum. We didn’t stop there, and we’ve got not just one… BUT TWO releases to share with you today!
 
 First, Opera has now added support for IPFS addressing to Opera Touch, their iOS browser.
 
-![A screenshot of Wikipedia on IPFS in Opera Touch](../assets/opera-ios-wikipedia-short.png 'Wikipedia on IPFS in Opera Touch')
+![A screenshot of Wikipedia on IPFS in Opera Touch](../assets/opera-ios-wikipedia-short.png "Wikipedia on IPFS in Opera Touch")
 
-Second, support for IPFS addressing in Opera desktop browser for Windows, macOS and Linux will be coming in their next release, currently planned for March 2021.
+Second, support for IPFS addressing in Opera desktop browser for Windows, macOS, and Linux will be coming in their next release, currently planned for March 2021.
 
-With these releases, Opera will not support ipfs:// and ipns:// addressing across their browser product line on all major operating systems: Windows, macOS, Linux, iOS and Android.
+As a special surprise for EthDenver, you can download a preview build of Opera for desktop which has IPFS addressing support! Give it a spin at [ethdenver2021.opera.com](https://ethdenver2021.opera.com).
 
-## How Do I use it?
+With these releases, Opera will now support `ipfs://` and `ipns://` addressing across their browser product line on all major operating systems: Windows, macOS, Linux, iOS, and Android.
 
-First, install Opera Touch on your iOS device. If you’re reading this on an iOS device, [click to install now](https://apps.apple.com/us/app/opera-touch-web-browser/id1411869974)
+## How do I use it?
+
+First, install Opera Touch on your iOS device. If you’re reading this on an iOS device, [click to install now](https://apps.apple.com/us/app/opera-touch-web-browser/id1411869974).
 
 ![](../assets/opera-ios-app-store-short.png)
 
-## How Does it Work?
+Then you can open content using IPFS protocol addresses, like the [blog you’re reading now](ipns://blog.ipfs.io), [Wikipedia](ipns://en.wikipedia-on-ipfs.org), or this [Persian room guardian](ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi) by [Anya Boz](https://www.anyabozartist.com/the-persian-cat). You can easily upload files to IPFS using the [IPFS desktop application](https://docs.ipfs.io/install/ipfs-desktop/) or [Share.ipfs.io](https://share.ipfs.io).
 
-Opera Touch supports navigating to addresses for ipfs:// and ipns:// protocol schemes, which are handled by a remote HTTP gateway. By default the gateway used is dweb.link, which is operated by Protocol Labs. TODO: Can select/change gateway?
+## How does it work?
 
-Native representation of IPFS addresses in browsers even when the content is loaded from an HTTP gateway as 1) it communicates to users the integrity guarantees built into the IPFS protocol and 2) it lets developers use IPFS addresses even as local node support is not yet implemented in most browsers.
+Opera Touch supports navigating to addresses for `ipfs://` and `ipns://` protocol schemes, which are handled by a remote HTTP gateway. By default the gateway used is `dweb.link`, which is operated by Protocol Labs. The ability to select a different gateway is coming in the next update of Opera Touch.
 
-## What’s Next?
+Native representation of IPFS addresses in browsers is important, even when the content is loaded from an HTTP gateway as IPFS URIs are resolved out of the box, without the need for any additional extensions or opt-in settings, which familiarizes users and developers with decentralized concepts of content-addressing and creates a path to readiness for when native nodes are available.
 
-Opera desktop browser support for IPFS addressing will ship soon, and we’re discussing what additional features to add next to build on top of this foundation of universal addressing support across the Opera browser line.
+## What’s next?
+
+Opera desktop browser support for IPFS addressing will ship soon, and we’re discussing what additional features to add next to build on top of this foundation of universal addressing support across the Opera browser line. Have ideas for what you’d like to see in Opera next? Let us know on the [IPFS forums](https://discuss.ipfs.io/), or tweet your ideas to [@Opera](https://twitter.com/opera) and [@IPFS](https://twitter.com/ipfs) on Twitter!
 
 [Install Opera Touch on iOS now!](https://apps.apple.com/us/app/opera-touch-web-browser/id1411869974)

--- a/src/_blog/ipfs-in-opera-touch-on-ios.md
+++ b/src/_blog/ipfs-in-opera-touch-on-ios.md
@@ -10,7 +10,6 @@ tags:
 - browsers
 - mobile
 - opera
-- ipfs
 author: Dietrich Ayala
 
 ---

--- a/src/_blog/ipfs-in-opera-touch-on-ios.md
+++ b/src/_blog/ipfs-in-opera-touch-on-ios.md
@@ -9,6 +9,8 @@ header_image: "/opera-ipfs-header.png"
 tags:
 - browsers
 - mobile
+- opera
+- ipfs
 author: Dietrich Ayala
 
 ---


### PR DESCRIPTION
Latest version from the old blog: https://github.com/ipfs/blog/blob/master/content/post/123-opera-ios-and-ipfs.md
Web Archive view: https://web.archive.org/web/20210209172608/https://blog.ipfs.io/2021-02-08-opera-ios-and-ipfs/

The version in the new re-platformed blog is the first draft pushed to the old blog ipfs/blog and this PR brings it up to date with the previously posted version.
