### PR TITLE
Video embeds and code blocks break layout by adding horizontal scroll to window on smaller devices

### DIFF
--- a/src/.vuepress/theme/layouts/BlogPost.vue
+++ b/src/.vuepress/theme/layouts/BlogPost.vue
@@ -79,13 +79,18 @@ export default {
 
 .blog > iframe {
   @apply mx-auto;
+}
+
+.blog > iframe[src*='youtube'],
+.blog > iframe[src*='vimeo'] {
   @apply max-w-full;
   height: auto;
   aspect-ratio: 16 / 9;
 }
 
 @supports not (aspect-ratio: 1 / 1) {
-  .blog > iframe {
+  .blog > iframe[src*='youtube'],
+  .blog > iframe[src*='vimeo'] {
     @apply h-52;
     @apply sm:h-80;
   }

--- a/src/.vuepress/theme/layouts/BlogPost.vue
+++ b/src/.vuepress/theme/layouts/BlogPost.vue
@@ -76,4 +76,18 @@ export default {
   padding-bottom: 0.5rem;
   border-bottom: 2px solid #d1d1d663;
 }
+
+.blog > iframe {
+  @apply mx-auto;
+  @apply max-w-full;
+  height: auto;
+  aspect-ratio: 16 / 9;
+}
+
+@supports not (aspect-ratio: 1 / 1) {
+  .blog > iframe {
+    @apply h-52;
+    @apply sm:h-80;
+  }
+}
 </style>

--- a/src/.vuepress/theme/styles/index.css
+++ b/src/.vuepress/theme/styles/index.css
@@ -9,16 +9,7 @@ pre {
   padding: 1.25rem 1.5rem;
   background-color: #0e2333;
   border-radius: 6px;
-}
-
-pre > code {
-  padding: 0;
-  background-color: transparent;
-  border-radius: 0;
-  color: #fff;
-  font-size: 0.85em;
-  white-space: pre-wrap;
-  word-break: break-all;
+  overflow-x: auto;
 }
 
 code {
@@ -28,4 +19,16 @@ code {
   border-radius: 3px;
   color: rgba(51, 51, 51, 0.8);
   font-size: 0.85em;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+pre > code {
+  padding: 0;
+  background-color: transparent;
+  border-radius: 0;
+  color: #fff;
+  font-size: 0.85em;
+  white-space: unset;
+  word-break: unset;
 }


### PR DESCRIPTION
The video embeds had fixed width and height, so on smaller devices the window would get an horizontal scroll. On some browsers the navigation would stick to the right completely hidden from the user.
You can see this issue in one of the latest blog posts: https://blog.ipfs.io/2021-04-14-scaling-ethereum/

I thought of adding the [`tailwindcss-aspect-ratio`](https://github.com/tailwindlabs/tailwindcss-aspect-ratio) plugin, but that would require a parent element.
To fix this I simply used `aspect-ratio` property with fallback to fixed heights with one media query breakpoint.
On browsers that don't support aspect ratio, there is a specific range of screen sizes where it looks weird but for that we'd need a smaller breakpoint to get all the sizes right. But it doesn't seem to affect a lot of devices, so I think this is a good compromise. The alternative would be to add a `xs` breakpoint to target those devices.

[Browser support for `aspect-ratio`](https://caniuse.com/mdn-css_properties_aspect-ratio):

<img width="943" alt="image" src="https://user-images.githubusercontent.com/2353186/114864912-7cb35380-9de9-11eb-99a0-01c2c094a2a0.png">

Overtime it will look better as browers implement aspect ratio.
Also centered the video on larger screens to match the behavior of the images.


## Before vs After iPhone 5S (Chrome)

<div>
<img width="200" alt="image" src="https://user-images.githubusercontent.com/2353186/114860988-9605d100-9de4-11eb-93bf-4a089fb82b81.png">
<img width="200" alt="image" src="https://user-images.githubusercontent.com/2353186/114864607-1b8b8000-9de9-11eb-9846-a0164174a0a1.png">
</div>

## After (Other screen sizes and browsers that do not support `aspect-ratio`)

<div>
<img width="150" alt="image" src="https://user-images.githubusercontent.com/2353186/114861170-cfd6d780-9de4-11eb-9424-865c240831c3.png">
<img width="150" alt="image" src="https://user-images.githubusercontent.com/2353186/114861236-e67d2e80-9de4-11eb-96d3-d36f042ca768.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/2353186/114861320-0280d000-9de5-11eb-868b-7444e60429b5.png">
<img width="884" alt="image" src="https://user-images.githubusercontent.com/2353186/114861411-25ab7f80-9de5-11eb-98ef-17d47193de1e.png">
</div>

