### PR TITLE
feat: add vuepress-plugin-chunkload-redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "vue": "^2.6.12",
         "vuepress": "^1.8.2",
         "vuepress-plugin-canonical": "^1.0.0",
+        "vuepress-plugin-chunkload-redirect": "^1.0.3",
         "vuepress-plugin-clean-urls": "^1.1.2",
         "vuepress-plugin-ipfs": "^1.0.2",
         "vuepress-plugin-robots": "^1.0.1",
@@ -23042,6 +23043,12 @@
       "integrity": "sha512-R2mcc+bp9VbKBQ3YIbCqUbWcWfmWSp1NIEyNGiLKkrcZmyUF/+0D48BqMCTx61AgJzWPW5DJzB6VkmpjbMIDbA==",
       "dev": true
     },
+    "node_modules/vuepress-plugin-chunkload-redirect": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-chunkload-redirect/-/vuepress-plugin-chunkload-redirect-1.0.3.tgz",
+      "integrity": "sha512-5VgvGw9t9v6DZU4NNksph9+en7v8NIo/gDKDnUdFkM+kuTnp4BAmWA+2JbpFIaw4Ke8R1txb2LZmAmuOum3DEA==",
+      "dev": true
+    },
     "node_modules/vuepress-plugin-clean-urls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vuepress-plugin-clean-urls/-/vuepress-plugin-clean-urls-1.1.2.tgz",
@@ -43964,6 +43971,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/vuepress-plugin-canonical/-/vuepress-plugin-canonical-1.0.0.tgz",
       "integrity": "sha512-R2mcc+bp9VbKBQ3YIbCqUbWcWfmWSp1NIEyNGiLKkrcZmyUF/+0D48BqMCTx61AgJzWPW5DJzB6VkmpjbMIDbA==",
+      "dev": true
+    },
+    "vuepress-plugin-chunkload-redirect": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-chunkload-redirect/-/vuepress-plugin-chunkload-redirect-1.0.3.tgz",
+      "integrity": "sha512-5VgvGw9t9v6DZU4NNksph9+en7v8NIo/gDKDnUdFkM+kuTnp4BAmWA+2JbpFIaw4Ke8R1txb2LZmAmuOum3DEA==",
       "dev": true
     },
     "vuepress-plugin-clean-urls": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "vue": "^2.6.12",
     "vuepress": "^1.8.2",
     "vuepress-plugin-canonical": "^1.0.0",
+    "vuepress-plugin-chunkload-redirect": "^1.0.3",
     "vuepress-plugin-clean-urls": "^1.1.2",
     "vuepress-plugin-ipfs": "^1.0.2",
     "vuepress-plugin-robots": "^1.0.1",

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -247,6 +247,7 @@ module.exports = {
         countdown: 0,
       },
     ],
+    'vuepress-plugin-chunkload-redirect',
     ['vuepress-plugin-ipfs', IPFS_DEPLOY],
   ],
   extraWatchFiles: ['.vuepress/config/head.js'],


### PR DESCRIPTION
Adds [vuepress-plugin-chunkload-redirect](https://github.com/cwaring/vuepress-plugin-chunkload-redirect) to handle chunkload errors transparently.