### PR TITLE
fix: use fleek api instead to trigger the build

### DIFF
--- a/.github/workflows/scheduled-publishing.yml
+++ b/.github/workflows/scheduled-publishing.yml
@@ -16,10 +16,7 @@ jobs:
         id: should_publish_step
       - name: Trigger Fleek Build
         if: ${{ steps.should_publish_step.outputs.should_publish == 'true' }}
-        id: deploy
-        uses: fleekhq/action-deploy@v1
-        with:
-          apiKey: ${{ secrets.FLEEK_API_KEY }}
+        run: curl -H "Authorization:${{ secrets.FLEEK_API_KEY }}" -H "Content-Type:application/json" -d '{"query":"mutation { triggerDeploy(siteId:\"${{ secrets.FLEEK_SITE_ID }}\") { status } }"}' https://api.fleek.co/graphql
       - name: Scheduled posts published
         if: ${{ steps.should_publish_step.outputs.should_publish == 'true' }}
         run: echo "Check https://blog.ipfs.io"


### PR DESCRIPTION
Build trigger was not working because fleek's github action expects a final build directory to be sent to be deployed. Instead we just want to trigger a build in fleek so we don't need to maintain multiple build setups.

This PR switches from using the github action to Fleek's http API.