### PR TITLE
fix: formatting of new features in js-ipfs-0.55.0

### DIFF
--- a/src/_blog/js-ipfs-0.55.0-greatly-improves-type-definitions.md
+++ b/src/_blog/js-ipfs-0.55.0-greatly-improves-type-definitions.md
@@ -69,7 +69,7 @@ The API changes are as follows:
 
 ## ✨New features
 
-* Support identity hash (\[`0x00](https://github.com/multiformats/multicodec/blob/master/table.csv#L2)) in`ipfs.block.get()`+`ipfs.dag.get()\` ([#3616](https://github.com/ipfs/js-ipfs/issues/3616)) ([28ad9ad](https://github.com/ipfs/js-ipfs/commit/28ad9ad6e50abb89a366ecd6b5301e848f0e9962))
+* Support identity hash ([`0x00`](https://github.com/multiformats/multicodec/blob/master/table.csv#L2)) in`ipfs.block.get()`+`ipfs.dag.get()` ([#3616](https://github.com/ipfs/js-ipfs/issues/3616)) ([28ad9ad](https://github.com/ipfs/js-ipfs/commit/28ad9ad6e50abb89a366ecd6b5301e848f0e9962))
 
 ## 🔨 Breaking changes
 


### PR DESCRIPTION
Fixes broken markdown formatting in the "new features" section of the js-ipfs 0.55.0 post.

**before**

<img width="868" alt="Screenshot 2021-05-12 at 14 33 56" src="https://user-images.githubusercontent.com/58871/117983715-1f9ab700-b32f-11eb-8b97-7468b6f33e89.png">

**after**

<img width="743" alt="Screenshot 2021-05-12 at 14 31 24" src="https://user-images.githubusercontent.com/58871/117983739-26292e80-b32f-11eb-9fd9-1516b3f803d8.png">
