### PR TITLE
feat: add PostMetaTitle for external links

### DIFF
--- a/src/.vuepress/theme/components/blog/PostMeta.vue
+++ b/src/.vuepress/theme/components/blog/PostMeta.vue
@@ -12,7 +12,7 @@
     </div>
     <UnstyledLink v-if="!onclick" :to="postPath" :title="title">
       <h1 class="type-h5 text-xl text-primary hover:underline clamp-3">
-        {{ title }}
+        <PostMetaTitle :title="title" :is-external="isExternal" />
       </h1>
     </UnstyledLink>
     <a
@@ -24,7 +24,7 @@
       @click="onclick"
     >
       <h1 class="type-h5 text-xl text-primary hover:underline clamp-3">
-        {{ title }}
+        <PostMetaTitle :title="title" :is-external="isExternal" />
       </h1>
     </a>
     <PostAuthor v-if="author" :author="author" />
@@ -50,9 +50,11 @@
 
 <script>
 import dayjs from 'dayjs'
+import { isExternal } from '@theme/util'
 import utc from 'dayjs/plugin/utc'
 import PostTag from '@theme/components/blog/PostTag'
 import PostAuthor from '@theme/components/blog/PostAuthor'
+import PostMetaTitle from '@theme/components/blog/PostMetaTitle'
 import UnstyledLink from '@theme/components/UnstyledLink'
 import countly from '../../util/countly'
 
@@ -62,6 +64,7 @@ export default {
     PostTag,
     PostAuthor,
     UnstyledLink,
+    PostMetaTitle,
   },
   props: {
     tags: {
@@ -103,6 +106,9 @@ export default {
       return dayjs
         .utc(this.date)
         .format(this.$themeLocaleConfig.dateFormat || 'YYYY-MM-DD')
+    },
+    isExternal() {
+      return isExternal(this.postPath)
     },
   },
   methods: {

--- a/src/.vuepress/theme/components/blog/PostMetaTitle.vue
+++ b/src/.vuepress/theme/components/blog/PostMetaTitle.vue
@@ -1,0 +1,7 @@
+<template functional>
+  <span v-if="props.isExternal"
+    ><span class="mr-4">{{ props.title }}</span
+    ><OutboundLink class="-ml-4 pl-1" />
+  </span>
+  <span v-else>{{ props.title }}</span>
+</template>


### PR DESCRIPTION
Adds outbound icon to external post titles.

![2021-05-27 at 12 58 23](https://user-images.githubusercontent.com/106938/119822168-42120000-beeb-11eb-9fd5-9e303898a7a6.png)

Displays in all cases except when a line title is clamped. I feel like this is a reasonable tradeoff considering the extra performance overhead of processing every title based on custom pixel breakpoints and also the regression we might get from SEO by trimming the post titles and separating into blocks.

alt to: #217
closes: #213