### PR TITLE
fix: remove typo from static news.json

### DIFF
--- a/scripts/data/news.json
+++ b/scripts/data/news.json
@@ -11,7 +11,7 @@
             "url": "https://rarible.medium.com/meet-metadata-guardians-trying-to-make-your-nft-collection-available-100-years-from-now-60a18baeed6c/"
         },
         {
-            "title": "Understanding the different types of NFTs (Indorse)(opens new window)",
+            "title": "Understanding the different types of NFTs (Indorse)",
             "date": "14 May 2021",
             "url": "https://blog.indorse.io/what-is-a-non-fungible-token-understanding-the-different-types-of-nfts-3ef29a2b2876/"
         }


### PR DESCRIPTION
Just noticed a tiny typo in the `news.json` file.