### PR TITLE
fix: broken link in Wikipedia blog post

### DIFF
--- a/src/_blog/2021-05-31-distributed-wikipedia-mirror-update.md
+++ b/src/_blog/2021-05-31-distributed-wikipedia-mirror-update.md
@@ -12,7 +12,7 @@ tags:
 
 ---
 * [Distributed Wikipedia Mirror](https://github.com/ipfs/distributed-wikipedia-mirror#readme) and [Kiwix](https://kiwix.org/) projects are happy to the announce **general availability** of **updated** [English](https://en.wikipedia-on-ipfs.org/) and [Turkish](https://tr.wikipedia-on-ipfs.org) mirrors, along with **new languages**: [Myanmar](https://my.wikipedia-on-ipfs.org/), [Arabic](https://ar.wikipedia-on-ipfs.org), [Chinese](https://zh.wikipedia-on-ipfs.org) and [Russian](https://ru.wikipedia-on-ipfs.org).
-* A handy, up-to-date list can be found at [ipfs.kiwix.org](ipfs.kiwix.org), and in the [`snapshot-hashes.yml`](https://github.com/ipfs/distributed-wikipedia-mirror/blob/main/snapshot-hashes.yml  "snapshot-hashes.yml") manifest.
+* A handy, up-to-date list can be found at [ipfs.kiwix.org](https://ipfs.kiwix.org), and in the [`snapshot-hashes.yml`](https://github.com/ipfs/distributed-wikipedia-mirror/blob/main/snapshot-hashes.yml  "snapshot-hashes.yml") manifest.
 * The idea of a distributed Wikipedia mirror goes back to 2017, when the IPFS Project created a snapshot of English and Turkish languages and put it on IPFS.  To learn why we did it, please read the original [Uncensorable Wikipedia on IPFS](https://blog.ipfs.io/24-uncensorable-wikipedia/) post.
 * Below is a short status update with improved usage instructions, current build process, open problems, and future work that could be contributed to the project.
 


### PR DESCRIPTION
Fixes a broken link in https://blog.ipfs.io/2021-05-31-distributed-wikipedia-mirror-update/