### PR TITLE
fix: comments on permalinks without slash

### DIFF
--- a/src/.vuepress/theme/components/blog/Comments.vue
+++ b/src/.vuepress/theme/components/blog/Comments.vue
@@ -6,18 +6,24 @@
 </template>
 
 <script>
+const safePermalink = (permalink) => {
+  // https://meta.discourse.org/t/referer-with-domain-name-in-the-slug-breaks-comments-embed/204807/4?u=lidel
+  const url = new URL('https://blog.ipfs.io/')
+  url.pathname = permalink
+  return url.toString()
+}
 export default {
   name: 'Comments',
   components: {},
   computed: {
     embedSrc() {
-      return `https://discuss.ipfs.io/embed/comments?embed_url=https://blog.ipfs.io${this.$frontmatter.permalink}`
+      return `https://discuss.ipfs.io/embed/comments?embed_url=${safePermalink(this.$frontmatter.permalink)}`
     },
   },
   mounted() {
     window.DiscourseEmbed = {
       discourseUrl: 'https://discuss.ipfs.io/',
-      discourseEmbedUrl: `https://blog.ipfs.io${this.$frontmatter.permalink}`,
+      discourseEmbedUrl: safePermalink(this.$frontmatter.permalink),
     }
     const d = document.createElement('script')
     d.type = 'text/javascript'


### PR DESCRIPTION
## Context 

Comments on some pages  are  broken due to the lack of leading `/` in permalink, for example: https://blog.ipfs.io/2021-06-17-opensea-ipfs-filecoin/

While we could add it everywhere,  or remove it and add it in the JS snippet responsible for embedding, both fixes are not future-proof, because someone could add a permalink that breaks the thing for a new blogpost.

## This fix

This PR aims to add normalization that makes sure every permalink works, 
no matter if it is defined with or without leading slash.

By leveraging `URL` behavior it solves problem described on [meta.discourse.org](https://meta.discourse.org/t/referer-with-domain-name-in-the-slug-breaks-comments-embed/204807/4?u=lidel) without breaking existing comment threads.
Permalinks with leading slash and without it will work the same, removing the problem from future blogposts.


## TODO

- [ ] confirm this fix works by building this to staging first and looking at the `/2021-06-17-opensea-ipfs-filecoin/` blogpost (currently still broken at https://blog.ipfs.io/2021-06-17-opensea-ipfs-filecoin/)
- [ ] confirm existing threads are not duplicated: open  https://blog.ipfs.io/2021-08-27-IPFS-io-gateway-outage-resolution/  and confirm it loads https://discuss.ipfs.io/t/august-20-ipfs-io-gateway-outage-resolution-next-steps-ipfs-blog-news/12314 and does not create a new topic 
- [ ] merge staging to master 