### PR TITLE
SEO: Add default canonical links to pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
         "tailwindcss-touch": "^1.0.1",
         "vue": "^2.6.12",
         "vuepress": "^1.8.2",
-        "vuepress-plugin-canonical": "^1.0.0",
         "vuepress-plugin-chunkload-redirect": "^1.0.3",
         "vuepress-plugin-clean-urls": "^1.1.2",
         "vuepress-plugin-ipfs": "^1.0.2",
@@ -23095,12 +23094,6 @@
         "object.getownpropertydescriptors": "^2.0.3"
       }
     },
-    "node_modules/vuepress-plugin-canonical": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vuepress-plugin-canonical/-/vuepress-plugin-canonical-1.0.0.tgz",
-      "integrity": "sha512-R2mcc+bp9VbKBQ3YIbCqUbWcWfmWSp1NIEyNGiLKkrcZmyUF/+0D48BqMCTx61AgJzWPW5DJzB6VkmpjbMIDbA==",
-      "dev": true
-    },
     "node_modules/vuepress-plugin-chunkload-redirect": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/vuepress-plugin-chunkload-redirect/-/vuepress-plugin-chunkload-redirect-1.0.3.tgz",
@@ -43958,12 +43951,6 @@
           }
         }
       }
-    },
-    "vuepress-plugin-canonical": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vuepress-plugin-canonical/-/vuepress-plugin-canonical-1.0.0.tgz",
-      "integrity": "sha512-R2mcc+bp9VbKBQ3YIbCqUbWcWfmWSp1NIEyNGiLKkrcZmyUF/+0D48BqMCTx61AgJzWPW5DJzB6VkmpjbMIDbA==",
-      "dev": true
     },
     "vuepress-plugin-chunkload-redirect": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "tailwindcss-touch": "^1.0.1",
     "vue": "^2.6.12",
     "vuepress": "^1.8.2",
-    "vuepress-plugin-canonical": "^1.0.0",
     "vuepress-plugin-chunkload-redirect": "^1.0.3",
     "vuepress-plugin-clean-urls": "^1.1.2",
     "vuepress-plugin-ipfs": "^1.0.2",

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -146,6 +146,7 @@ module.exports = {
       },
     ],
     [require('./plugins/pageData')],
+    [require('./plugins/canonical')],
     [require('./plugins/vuepress-plugin-trigger-scroll')],
     [
       '@vuepress/blog',

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -145,15 +145,6 @@ module.exports = {
         notFoundPath: '/ipfs-404.html',
       },
     ],
-    [
-      'vuepress-plugin-canonical',
-      CANONICAL_BASE
-        ? {
-            baseURL: CANONICAL_BASE,
-            stringExtension: true,
-          }
-        : false,
-    ],
     [require('./plugins/pageData')],
     [require('./plugins/vuepress-plugin-trigger-scroll')],
     [

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -38,8 +38,7 @@ const themeConfigDefaults = {
     },
     {
       text: 'Security',
-      link:
-        'https://github.com/ipfs/community/blob/master/CONTRIBUTING.md#security-issues',
+      link: 'https://github.com/ipfs/community/blob/master/CONTRIBUTING.md#security-issues',
     },
   ],
   footerLegal: '',
@@ -106,13 +105,11 @@ module.exports = {
           { text: 'Press', link: 'https://ipfs.tech/media/' },
           {
             text: 'Code of conduct',
-            link:
-              'https://github.com/ipfs/community/blob/master/code-of-conduct.md',
+            link: 'https://github.com/ipfs/community/blob/master/code-of-conduct.md',
           },
           {
             text: 'Security',
-            link:
-              'https://github.com/ipfs/community/blob/master/CONTRIBUTING.md#security-issues',
+            link: 'https://github.com/ipfs/community/blob/master/CONTRIBUTING.md#security-issues',
           },
         ],
         headerLinks: [
@@ -146,7 +143,7 @@ module.exports = {
       },
     ],
     [require('./plugins/pageData')],
-    [require('./plugins/canonical')],
+    [require('./plugins/canonical'), { CANONICAL_BASE }],
     [require('./plugins/vuepress-plugin-trigger-scroll')],
     [
       '@vuepress/blog',

--- a/src/.vuepress/plugins/canonical.js
+++ b/src/.vuepress/plugins/canonical.js
@@ -1,4 +1,4 @@
-//                                                         👇 add trailing slash if not present
+//                                                         👇 ensure one trailing slash is present
 const normalizePath = (path) => path.replace('/_blog', '').replace(/\/*$/, '/')
 
 module.exports = ({ CANONICAL_BASE } = {}) => ({

--- a/src/.vuepress/plugins/canonical.js
+++ b/src/.vuepress/plugins/canonical.js
@@ -1,16 +1,12 @@
-module.exports = (options, context) => ({
-  name: 'vuepress-default-canonical',
-  extendPageData($page) {
-    const { frontmatter } = $page
-    // If no canonicalUrl is explictly defined in the Frontmatter, add it based on the permaLink
-    if (!frontmatter.canonicalUrl && frontmatter.permalink) {
-      frontmatter.canonicalUrl = `${$page?._context?.themeConfig?.domain}${frontmatter.permalink}`
-      return
-    }
+const normalizePath = (path) => path.replace('/_blog', '')
 
-    if (!frontmatter.permalink && $page._permalink) {
-      // Set the canonical URL to theme pages (which don't have a frontmatter permalink)
-      frontmatter.canonicalUrl = `${$page?._context?.themeConfig?.domain}`
+module.exports = ({ CANONICAL_BASE } = {}) => ({
+  name: 'vuepress-default-canonical',
+  extendPageData({ frontmatter, path }) {
+    // If no canonicalUrl is explicitly defined in the frontmatter, construct it from the permaLink or $page.path
+    if (!frontmatter.canonicalUrl && CANONICAL_BASE) {
+      frontmatter.canonicalUrl =
+        CANONICAL_BASE + normalizePath(frontmatter.permalink || path || '')
     }
   },
 })

--- a/src/.vuepress/plugins/canonical.js
+++ b/src/.vuepress/plugins/canonical.js
@@ -1,5 +1,5 @@
 //                                                         👇 add trailing slash if not present
-const normalizePath = (path) => path.replace('/_blog', '').replace(/\/?$/, '/')
+const normalizePath = (path) => path.replace('/_blog', '').replace(/\/*$/, '/')
 
 module.exports = ({ CANONICAL_BASE } = {}) => ({
   name: 'vuepress-default-canonical',

--- a/src/.vuepress/plugins/canonical.js
+++ b/src/.vuepress/plugins/canonical.js
@@ -1,4 +1,5 @@
-const normalizePath = (path) => path.replace('/_blog', '')
+//                                                         👇 add trailing slash if not present
+const normalizePath = (path) => path.replace('/_blog', '').replace(/\/?$/, '/')
 
 module.exports = ({ CANONICAL_BASE } = {}) => ({
   name: 'vuepress-default-canonical',

--- a/src/.vuepress/plugins/canonical.js
+++ b/src/.vuepress/plugins/canonical.js
@@ -1,0 +1,16 @@
+module.exports = (options, context) => ({
+  name: 'vuepress-default-canonical',
+  extendPageData($page) {
+    const { frontmatter } = $page
+    // If no canonicalUrl is explictly defined in the Frontmatter, add it based on the permaLink
+    if (!frontmatter.canonicalUrl && frontmatter.permalink) {
+      frontmatter.canonicalUrl = `${$page?._context?.themeConfig?.domain}${frontmatter.permalink}`
+      return
+    }
+
+    if (!frontmatter.permalink && $page._permalink) {
+      // Set the canonical URL to theme pages (which don't have a frontmatter permalink)
+      frontmatter.canonicalUrl = `${$page?._context?.themeConfig?.domain}`
+    }
+  },
+})

--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,0 @@
-# Hello World
-
-Welcome to the VuePress website starter kit
-
-{{ $site }}


### PR DESCRIPTION
## Context

After discoving that the plugin we're using [isn't working](https://github.com/IOriens/vuepress-plugin-canonical/issues/2) and that we don't have any canonical tags on the blog, I fixed it by building a small plugin.

## What's in the PR
- Remove non functioning canonical plugin
- Add custom plugin to add the canonical tag to blog posts

## How to test

One of the quick ways to test/check canonical tags is https://seominion.com/ a browser plugin that you can run on any page. 

If you run it on https://blog.ipfs.tech/ currently, you will see there's none.

<img width="1279" alt="Screen Shot 2022-08-22 at 7 54 49 PM" src="https://user-images.githubusercontent.com/1992255/185987275-57c0a5cd-387e-434c-a170-5f62365805bf.png">

This PR fixes it for every blog post while still allowing to override via the `frontmatter.canonicalUrl`