### PR TITLE
Add release note: Kubo v0.18.0

### DIFF
--- a/src/_blog/releasenotes.md
+++ b/src/_blog/releasenotes.md
@@ -4,85 +4,92 @@ type: Release notes
 sitemap:
   exclude: true
 data:
+- title: 'Just released: Kubo 0.18.0!'
+  date: '2023-01-23'
+  publish_date: null
+  path: https://github.com/ipfs/kubo/releases/tag/v0.18.0
+  tags:
+  - go-ipfs
+  - kubo
 - title: 'Just released: Kubo 0.17.0!'
-  date: 2022-11-22
-  publish_date: 
+  date: '2022-11-22'
+  publish_date: null
   path: https://github.com/ipfs/kubo/releases/tag/v0.17.0
   tags:
   - go-ipfs
   - kubo
 - title: js-ipfs 0.64.0
-  date: 2022-09-07
-  publish_date: 2022-09-07T12:00:00.000+00:00
+  date: '2022-09-07'
+  publish_date: '2022-09-07T12:00:00+00:00'
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs-v0.64.0
-  card_image: "/header-image-js-ipfs-placeholder.png"
+  card_image: /header-image-js-ipfs-placeholder.png
   tags:
   - js-ipfs
 - title: js-ipfs 0.63.0
-  date: 2022-05-22
-  publish_date: 2022-05-22T12:00:00.000+00:00
+  date: '2022-05-22'
+  publish_date: '2022-05-22T12:00:00+00:00'
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs-v0.63.0
-  card_image: "/header-image-js-ipfs-placeholder.png"
+  card_image: /header-image-js-ipfs-placeholder.png
   tags:
   - js-ipfs
 - title: js-ipfs 0.62.0
-  date: 2022-01-27
-  publish_date: 2022-01-27T12:00:00.000+00:00
+  date: '2022-01-27'
+  publish_date: '2022-01-27T12:00:00+00:00'
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs-v0.62.0
-  card_image: "/header-image-js-ipfs-placeholder.png"
+  card_image: /header-image-js-ipfs-placeholder.png
   tags:
   - js-ipfs
 - title: js-ipfs 0.61.0
-  date: 2021-12-15
-  publish_date: 2021-12-21T12:00:00.000+00:00
+  date: '2021-12-15'
+  publish_date: '2021-12-21T12:00:00+00:00'
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.61.0
-  card_image: "/header-image-js-ipfs-placeholder.png"
+  card_image: /header-image-js-ipfs-placeholder.png
   tags:
   - js-ipfs
 - title: js-libp2p v0.40.0
-  date: 2022-10-17
-  publish_date: 2022-10-17T12:00:00.000+00:00
+  date: '2022-10-17'
+  publish_date: '2022-10-17T12:00:00+00:00'
   path: https://github.com/libp2p/js-libp2p/releases/tag/v0.40.0
-  card_image: "/header-image-libp2p.png"
+  card_image: /header-image-libp2p.png
   tags:
   - libp2p
 - title: js-libp2p v0.39.0
-  date: 2022-09-07
-  publish_date: 2022-09-07T12:00:00.000+00:00
+  date: '2022-09-07'
+  publish_date: '2022-09-07T12:00:00+00:00'
   path: https://github.com/libp2p/js-libp2p/releases/tag/v0.39.0
-  card_image: "/header-image-libp2p.png"
+  card_image: /header-image-libp2p.png
   tags:
   - libp2p
 - title: js-libp2p v0.38.0
-  date: 2022-08-17
-  publish_date: 2022-08-17T12:00:00.000+00:00
+  date: '2022-08-17'
+  publish_date: '2022-08-17T12:00:00+00:00'
   path: https://github.com/libp2p/js-libp2p/releases/tag/v0.38.0
-  card_image: "/header-image-libp2p.png"
+  card_image: /header-image-libp2p.png
   tags:
   - libp2p
 - title: 'Just released: Kubo 0.16.0!'
-  date: 2022-10-04
-  publish_date: 
+  date: '2022-10-04'
+  publish_date: null
   path: https://github.com/ipfs/kubo/releases/tag/v0.16.0
   tags:
   - go-ipfs
 - title: 'Just released: Kubo (formerly go-ipfs) 0.15.0!'
-  date: 2022-08-30
-  publish_date: 
+  date: '2022-08-30'
+  publish_date: null
   path: https://github.com/ipfs/kubo/releases/tag/v0.15.0
   tags:
   - go-ipfs
   - kubo
 - title: Kubo (formerly go-ipfs) v0.14.0 Release is out!
-  date: 2022-07-21
-  publish_date: 
+  date: '2022-07-21'
+  publish_date: null
   path: https://github.com/ipfs/kubo/releases/tag/v0.14.0
   tags:
   - go-ipfs
   - kubo
 - title: go-ipfs 0.13.0 Release
-  date: 2022-06-09
-  publish_date: 
+  date: '2022-06-09'
+  publish_date: null
   path: https://github.com/ipfs/go-ipfs/releases/tag/v0.13.0
   tags:
   - browsers
@@ -94,222 +101,221 @@ data:
   - IPLD
   - go-ipfs
 - title: js-libp2p v0.37.0
-  date: 2022-05-16
-  publish_date: 
+  date: '2022-05-16'
+  publish_date: null
   path: https://github.com/libp2p/js-libp2p/releases/tag/v0.37.0
-  card_image: "/header-image-libp2p.png"
+  card_image: /header-image-libp2p.png
   tags:
   - libp2p
 - title: go-ipfs 0.12.0 Release
-  date: 2022-02-18
-  publish_date: 
+  date: '2022-02-18'
+  publish_date: null
   path: https://github.com/ipfs/go-ipfs/releases/tag/v0.12.0
   tags:
   - blockstore
   - go-ipfs
   - IPFS Desktop
 - title: js-libp2p v0.36.0
-  date: 2022-01-25
-  publish_date: 
+  date: '2022-01-25'
+  publish_date: null
   path: https://github.com/libp2p/js-libp2p/releases/tag/v0.36.0
-  card_image: "/header-image-libp2p.png"
+  card_image: /header-image-libp2p.png
   tags:
   - libp2p
 - title: go-ipfs 0.11.0 Release
-  date: 2021-12-09
-  publish_date: 
+  date: '2021-12-09'
+  publish_date: null
   path: https://github.com/ipfs/go-ipfs/releases/tag/v0.11.0
   tags:
   - go-ipfs
 - title: js-ipfs 0.60.0
-  date: 2021-11-12
-  publish_date: 
+  date: '2021-11-12'
+  publish_date: null
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.60.0
-  card_image: "/header-image-js-ipfs-placeholder.png"
+  card_image: /header-image-js-ipfs-placeholder.png
   tags:
   - js-ipfs
 - title: js-ipfs 0.59.0
-  date: 2021-09-24
-  publish_date: 
+  date: '2021-09-24'
+  publish_date: null
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.59.0
-  card_image: "/header-image-js-ipfs-placeholder.png"
+  card_image: /header-image-js-ipfs-placeholder.png
   tags:
   - js-ipfs
 - title: go-ipfs v0.10.0 has been released!
-  date: 2021-10-01
-  publish_date: 
+  date: '2021-10-01'
+  publish_date: null
   path: https://github.com/ipfs/go-ipfs/releases/tag/v0.10.0
   tags:
   - Bitswap
   - go-ipfs
   - IPLD
 - title: js-ipfs 0.58.0
-  date: 2021-08-17
-  publish_date: 
+  date: '2021-08-17'
+  publish_date: null
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.58.0
-  card_image: "/header-image-js-ipfs-placeholder.png"
+  card_image: /header-image-js-ipfs-placeholder.png
   tags:
   - js-ipfs
 - title: IPFS Cluster 0.14.1
-  date: 2021-08-16
-  publish_date: 
+  date: '2021-08-16'
+  publish_date: null
   path: https://github.com/ipfs/ipfs-cluster/releases/tag/v0.14.1
-  card_image: "/077-collaborative-clusters-header-image.png"
+  card_image: /077-collaborative-clusters-header-image.png
   tags:
   - IPFS Cluster
 - title: js-ipfs 0.57.0
-  date: 2021-08-11
-  publish_date: 
+  date: '2021-08-11'
+  publish_date: null
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.57.0
-  card_image: "/header-image-js-ipfs-placeholder.png"
+  card_image: /header-image-js-ipfs-placeholder.png
   tags:
   - js-ipfs
 - title: js-ipfs 0.56.0
-  date: 2021-07-27
-  publish_date: 2021-07-27T12:00:00.000+00:00
+  date: '2021-07-27'
+  publish_date: '2021-07-27T12:00:00+00:00'
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.56.0
-  card_image: "/header-image-js-ipfs-placeholder.png"
+  card_image: /header-image-js-ipfs-placeholder.png
   tags:
   - js-ipfs
 - title: go-ipfs 0.9.1
-  date: 2021-07-21
-  publish_date: 
+  date: '2021-07-21'
+  publish_date: null
   path: https://github.com/ipfs/go-ipfs/releases/tag/v0.9.1
   tags:
   - go-ipfs
 - title: IPFS Cluster 0.14.0
-  date: 2021-07-09
-  publish_date: 
+  date: '2021-07-09'
+  publish_date: null
   path: https://github.com/ipfs/ipfs-cluster/blob/master/CHANGELOG.md
   tags:
   - IPFS Cluster
 - title: go-ipfs 0.9.0
-  date: 2021-06-22
-  publish_date: 
+  date: '2021-06-22'
+  publish_date: null
   path: https://github.com/ipfs/go-ipfs/releases/tag/v0.9.0
   tags:
   - go-ipfs
 - title: js-ipfs 0.55.1
-  date: 2021-05-11
-  publish_date: 2021-05-11T12:00:00.000+00:00
+  date: '2021-05-11'
+  publish_date: '2021-05-11T12:00:00+00:00'
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.55.1
-  card_image: "/header-image-js-ipfs-placeholder.png"
+  card_image: /header-image-js-ipfs-placeholder.png
   tags:
   - js-ipfs
 - title: js-ipfs 0.55.0
-  date: 2021-05-10
-  publish_date: 
+  date: '2021-05-10'
+  publish_date: null
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.55.0
-  card_image: "/header-image-js-ipfs-placeholder.png"
+  card_image: /header-image-js-ipfs-placeholder.png
   tags:
   - breaking change
   - js-ipfs
 - title: IPFS Desktop v0.15.0
-  date: 2021-05-05
-  publish_date: 
+  date: '2021-05-05'
+  publish_date: null
   path: https://github.com/ipfs/ipfs-desktop/releases/tag/v0.15.0
   tags:
   - pinning
   - Windows
   - IPFS Desktop
 - title: ipfs-webui v2.12.0
-  date: 2021-04-19
-  publish_date: 
+  date: '2021-04-19'
+  publish_date: null
   path: https://github.com/ipfs/ipfs-webui/releases/tag/v2.12.0
   tags:
   - release notes
 - title: IPFS Remote Pinning GitHub Action
-  date: 2021-03-21
+  date: '2021-03-21'
   path: https://github.com/marketplace/actions/ipfs-remote-pinning
-  card_image: "/2021-03-23-cardheader-ipfs-remote-pinning.png"
+  card_image: /2021-03-23-cardheader-ipfs-remote-pinning.png
   tags:
   - pinning
 - title: js-ipfs 0.54.3
-  date: 2021-03-09
+  date: '2021-03-09'
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.54.3
   tags:
   - js-ipfs
   - AEgir
 - title: IPFS Companion 2.17.3
-  date: 2021-01-29
+  date: '2021-01-29'
   path: https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.17.3
   tags:
   - IPFS Companion
-  card_image: "/release-notes-placeholder.png"
+  card_image: /release-notes-placeholder.png
 - title: IPFS Companion 2.17.2
-  date: 2021-01-20
+  date: '2021-01-20'
   path: https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.17.2
   tags:
   - IPFS Companion
-  card_image: "/release-notes-placeholder.png"
+  card_image: /release-notes-placeholder.png
 - title: IPFS Desktop 0.14.0
-  date: 2021-02-23
+  date: '2021-02-23'
   path: https://github.com/ipfs-shipyard/ipfs-desktop/releases/tag/v0.14.0
   tags:
   - IPFS Desktop
-  card_image: "/release-notes-placeholder.png"
+  card_image: /release-notes-placeholder.png
 - title: go-ipfs 0.8.0
-  date: 2021-02-18
+  date: '2021-02-18'
   path: https://github.com/ipfs/go-ipfs/releases/tag/v0.8.0
   tags:
   - go-ipfs
-  card_image: "/release-notes-placeholder.png"
+  card_image: /release-notes-placeholder.png
 - title: IPFS Cluster 0.13.1
-  date: 2021-01-14
+  date: '2021-01-14'
   path: https://github.com/ipfs/ipfs-cluster/releases/tag/v0.13.1
   tags:
   - IPFS Cluster
-  card_image: "/release-notes-placeholder.png"
+  card_image: /release-notes-placeholder.png
 - name: IPFS Companion 2.17.0
   title: IPFS Companion 2.17.0
   path: https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.17.0
-  date: 2021-01-11
+  date: '2021-01-11'
   tags:
   - IPFS Companion
-  card_image: "/release-notes-placeholder.png"
+  card_image: /release-notes-placeholder.png
 - name: go-libp2p 0.13.0
   title: go-libp2p 0.13.0
   path: https://github.com/libp2p/go-libp2p/releases/tag/v0.13.0
-  date: 2020-12-19
+  date: '2020-12-19'
   tags:
   - libp2p
-  card_image: "/release-notes-placeholder.png"
+  card_image: /release-notes-placeholder.png
 - name: js-libp2p 0.30.0
   title: js-libp2p 0.30.0
   path: https://github.com/libp2p/js-libp2p/releases/tag/v0.30.0
-  date: 2020-12-16
+  date: '2020-12-16'
   tags:
   - libp2p
-  card_image: "/release-notes-placeholder.png"
+  card_image: /release-notes-placeholder.png
 - name: js-ipfs 0.52.3
   title: js-ipfs 0.52.3
   path: https://github.com/ipfs/js-ipfs/releases/tag/ipfs%400.52.3
-  date: 2020-12-16
+  date: '2020-12-16'
   tags:
   - js-ipfs
 - name: IPFS Desktop 0.13.2
   title: IPFS Desktop 0.13.2
   path: https://github.com/ipfs-shipyard/ipfs-desktop/releases/tag/v0.13.2
-  date: 2020-10-12
+  date: '2020-10-12'
   tags:
   - IPFS Desktop
 - name: IPFS Web UI 2.11.4
   title: IPFS Web UI 2.11.4
   path: https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.11.4
-  date: 2020-10-12
+  date: '2020-10-12'
   tags:
   - IPFS Web UI
 - name: go-ipfs 0.7.0
   title: go-ipfs 0.7.0
   path: https://github.com/ipfs/go-ipfs/releases/tag/v0.7.0
-  date: 2020-10-12
+  date: '2020-10-12'
   tags:
   - go-ipfs
 - name: IPFS Cluster 0.13.0
   title: IPFS Cluster 0.13.0
   path: https://github.com/ipfs/ipfs-cluster/releases/tag/v0.13.0
-  date: 2020-10-12
+  date: '2020-10-12'
   tags:
   - IPFS Cluster
-
 ---


### PR DESCRIPTION
This PR adds a release note for the v0.18.0 Kubo release.

The formatting diff is introduced because I used [yq](https://mikefarah.gitbook.io/yq/) to automate the release note creation.