### PR TITLE
js-ipfs deprecation - replaced by Helia

### DIFF
--- a/src/_blog/2023-05-js-ipfs-deprecation-for-helia.md
+++ b/src/_blog/2023-05-js-ipfs-deprecation-for-helia.md
@@ -1,0 +1,25 @@
+---
+title: ⛔️ js-IPFS deprecation / replaced by Helia 🌞
+description: 'js-IPFS is being deprecated, and has been superseded by Helia.'
+author: Alex Potsides (@achingbrain)
+date: 2023-05-26
+permalink: '/202305-js-ipfs-deprecation-for-helia/'
+header_image: '/header-image-js-ipfs-placeholder.png'
+tags:
+  - 'helia'
+  - 'js-ipfs'
+---
+
+**TL;DR: [js-IPFS](https://github.com/ipfs/js-ipfs) is being deprecated, and has been superseded by [Helia](https://github.com/ipfs/helia).**
+
+There are exciting times ahead for IPFS in JS. Some of you may have already heard of [Helia](https://github.com/ipfs/helia), the new implementation that's designed as a composable, lightweight, and modern replacement for js-IPFS.
+
+It has a [simplified API](https://ipfs.github.io/helia/interfaces/_helia_interface.Helia.html) which can be extended by other modules depending on the requirements of your application such as [@helia/unixfs](https://github.com/ipfs/helia-unixfs), [@helia/ipns](https://github.com/ipfs/helia-ipns), [@helia/dag-cbor](https://github.com/ipfs/helia-dag-cbor) and [others](https://github.com/ipfs/helia#-code-structure).
+
+It ships with the latest and greatest libp2p, which means it has the best connectivity options, including the new [WebTransport](https://github.com/libp2p/js-libp2p-webtransport) and [WebRTC](https://github.com/libp2p/js-libp2p-webrtc) transports that dramatically improve the connectivity options for browser environments.
+
+[js-IPFS is in the process of being deprecated](https://github.com/ipfs/js-ipfs/issues/4336) so you should port your apps to Helia to receive bug fixes, features, and performance improvements moving forwards.
+
+📚 [Learn more about this deprecation](https://github.com/ipfs/js-ipfs/issues/4336) or [how to migrate](https://github.com/ipfs/helia/wiki/Migrating-from-js-IPFS).
+
+More new blog content discussing Helia coming soon!


### PR DESCRIPTION
This is a blog post accompanying the js-ipfs deprecation work that is active at https://github.com/ipfs/js-ipfs/issues/4336

## Why now?
We were originally going to do a discuss.ipfs.tech post ([proposed text](https://www.notion.so/pl-strflt/2023Q2-js-ipfs-Deprecation-c84d5d4f661044198ba6e63bf0a34790?pvs=4#665338dad2ae4408abde8e5f88f2d7ec)).  Doing this as a blog entry will cause the discuss.ipfs.tech post to be generated while getting broader reach for the message.

Switching from a discuss.ipfs.tech post to a blog entry came to mind when thinking about the next IPFS Newsletter.  I know we can manually submit newsletter additions, but this should get it scooped up by default.

(With deprecations, the more expansive the communication the better to avoid surprises.)

## Shouldn't we add more text about Helia?
Ideally yes, but I'm just taking the discuss.ipfs.tech text we had drafted.  We will followup with an "announcing Helia" post where we can give more info about Helia.  

## Do we need to act quickly?
If folks aren't comfortable with this blog entry and more work is required, we can park it and should just fall back to a discuss.ipfs.tech post.

## Open items
- [ ] (not blocking - can be added later) get a better header image: https://www.notion.so/js-ipfs-deprecation-blog-banner-e18b8b0389dc44d1b39ac0ea02d4d243