### PR TITLE
Render blog posts even if their date is in the future

### DIFF
--- a/src/.vuepress/plugins/pageData.js
+++ b/src/.vuepress/plugins/pageData.js
@@ -10,16 +10,6 @@ function shouldBeHidden(frontmatter) {
     shouldHide = shouldHide || frontmatter.sitemap.exclude
   }
 
-  // scheduled posts
-  // see auto-publishing of scheduled posts here: https://github.com/ipfs/ipfs-blog/issues/147
-  if (
-    !shouldHide &&
-    frontmatter.permalink && // permalink is unique to posts
-    frontmatter.date
-  ) {
-    shouldHide = shouldHide || isDateInFuture(frontmatter.date)
-  }
-
   // scheduled links (path is unique to links)
   if (!shouldHide && frontmatter.path && frontmatter.publish_date) {
     shouldHide = shouldHide || isDateInFuture(frontmatter.publish_date)


### PR DESCRIPTION
## TL;DR

This PR ensures that blog posts with a frontmatter date in the future are rendered. This is important for when we have PRs with a future publish date that cannot be previewed.