### PR TITLE
ci: run workflow with secrets for forks too

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
   pull_request:
+  # 👇 is needed to run on PRs from forks with access to secrets.
+  # ⚠️ Should only be used with the repo configured to require workflow approval for all external contributors
+  pull_request_target:
+
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Why

This PR enables fork builds to also access secrets for preview builds. There's the risk of secrets getting exposed if the workflows are modified. This can only be circumvented by requiring manual approval for workflow runs.